### PR TITLE
Filter::getLocalColumnName(): no more default value

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2149,7 +2149,7 @@ class Criteria
     public function turnFiltersToUpdateValues()
     {
         foreach ($this->filterCollector->getColumnFilters() as $filter) {
-            $columnIdentifier = $filter->getLocalColumnName();
+            $columnIdentifier = $filter->getLocalColumnName(false);
             $value = $filter->getValue();
             $this->setUpdateValue($columnIdentifier, $value);
         }

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -162,7 +162,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return string
      */
-    public function getLocalColumnName(bool $useQuoteIfEnable = false): string
+    public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $useQuoteIfEnable
             ? $this->query->quoteColumnIdentifier($this->table, $this->column)

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -192,7 +192,7 @@ class DeprecatedCriteriaMethods extends Criteria
         $tables = [];
         foreach ($this->criteria->filterCollector->getColumnFilters() as $filter) {
             $tableName = $filter->getTableAlias();
-            $tables[$tableName][] = $filter->getLocalColumnName();
+            $tables[$tableName][] = $filter->getLocalColumnName(false);
         }
         foreach ($this->criteria->updateValues->getColumnExpressionsInQuery() as $columnExpression) {
             $tableName = substr($columnExpression, 0, strrpos($columnExpression, '.') ?: null);

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractColumnFilter.php
@@ -46,11 +46,11 @@ abstract class AbstractColumnFilter extends AbstractFilter
     }
 
     /**
-     * @param bool $useQuoteIfEnable = true
+     * @param bool $useQuoteIfEnable
      *
      * @return string
      */
-    public function getLocalColumnName(bool $useQuoteIfEnable = true): string
+    public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $this->queryColumn->getColumnExpressionInQuery($useQuoteIfEnable);
     }

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilterClauseLiteral.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilterClauseLiteral.php
@@ -67,7 +67,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
      *
      * @return string
      */
-    public function getLocalColumnName(bool $useQuoteIfEnable = false): string
+    public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $this->resolvedColumns ? $this->resolvedColumns[0]->getColumnExpressionInQuery($useQuoteIfEnable) : '';
     }

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractInnerQueryFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractInnerQueryFilter.php
@@ -70,7 +70,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
      *
      * @return string
      */
-    public function getLocalColumnName(bool $useQuoteIfEnable = true): string
+    public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $this->queryColumn ? $this->queryColumn->getColumnExpressionInQuery($useQuoteIfEnable) : '';
     }

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/BinaryColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/BinaryColumnFilter.php
@@ -32,7 +32,7 @@ class BinaryColumnFilter extends AbstractColumnFilter
         $isBinary = ($this->operator === Criteria::BINARY_ALL);
         $compareTo = $isBinary ? $this->addParameter($paramCollector) : '0';
 
-        $field = $this->getLocalColumnName();
+        $field = $this->getLocalColumnName(true);
 
         return "$field & $bindParam = $compareTo";
     }

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnFilterInterface.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnFilterInterface.php
@@ -41,7 +41,7 @@ interface ColumnFilterInterface
      *
      * @return string
      */
-    public function getLocalColumnName(bool $useQuoteIfEnable = false): string;
+    public function getLocalColumnName(bool $useQuoteIfEnable): string;
 
     /**
      * Column name without table prefix.

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterCollector.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterCollector.php
@@ -131,7 +131,7 @@ class FilterCollector
      */
     public function getColumnExpressionsInQuery(): array
     {
-        return array_map(fn ($c) => $c->getLocalColumnName(), $this->columnFilters);
+        return array_map(fn ($c) => $c->getLocalColumnName(false), $this->columnFilters);
     }
 
     /**
@@ -141,7 +141,7 @@ class FilterCollector
     {
         $map = [];
         foreach ($this->columnFilters as $filter) {
-            $map[$filter->getLocalColumnName()] = $filter;
+            $map[$filter->getLocalColumnName(false)] = $filter;
         }
 
         return $map;

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/InColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/InColumnFilter.php
@@ -31,7 +31,7 @@ class InColumnFilter extends AbstractColumnFilter
             $param = $this->buildParameterWithValue($value);
             $bindParams[] = $this->addParameter($paramCollector, $param);
         }
-        $field = $this->getLocalColumnName();
+        $field = $this->getLocalColumnName(true);
         $paramList = implode(',', $bindParams);
 
         return "$field{$this->operator}($paramList)";

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/LikeColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/LikeColumnFilter.php
@@ -20,7 +20,7 @@ class LikeColumnFilter extends ColumnFilter
      */
     protected function buildFilterClause(array &$paramCollector): string
     {
-        $field = $this->getLocalColumnName();
+        $field = $this->getLocalColumnName(true);
         $bindParam = $this->addParameter($paramCollector);
 
         if ($this->isIgnoreCase()) {

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -96,7 +96,7 @@ class CriteriaTest extends BookstoreTestBase
 
         $this->assertCount(1, $columnFilters);
         $this->assertEquals($value, reset($columnFilters)->getValue());
-        $this->assertEquals($columnIdentifier, reset($columnFilters)->getLocalColumnName());
+        $this->assertEquals($columnIdentifier, reset($columnFilters)->getLocalColumnName(false));
     }
 
     /**
@@ -966,7 +966,7 @@ class CriteriaTest extends BookstoreTestBase
         $c->addAsColumn('column_alias', 'tbl.COL1');
         $crit = $c->getNewCriterion('column_alias', 'FOO');
         $this->assertNull($crit->getTableAlias());
-        $this->assertEquals('column_alias', $crit->getLocalColumnName());
+        $this->assertEquals('column_alias', $crit->getLocalColumnName(false));
     }
 
     /**


### PR DESCRIPTION
Filter::getLocalColumnName() had a default value that was not consistent across child classes. There should not be a default value on a method like this.

Additional fix for #42 