### PR TITLE
Update psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         }
     ],
     "require": {
+        "ext-pdo": "*",
+        "ext-json": "*",
+        "ext-xml": "*",
         "php": ">=8.1",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/yaml": "^5.0.0 || ^6.0.0 || ^7.0.0",
@@ -26,24 +29,27 @@
         "symfony/filesystem": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "symfony/finder": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "symfony/translation": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "symfony/validator": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "symfony/validator": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "symfony/polyfill-php82": "^1.31",
+        "symfony/polyfill-php83": "^1.31",
+        "symfony/polyfill-php84": "^1.31"
     },
     "require-dev": {
-        "ext-pdo": "*",
-        "ext-json": "*",
-        "ext-xml": "*",
         "monolog/monolog": "^1.3 || ^2.3 || ^3.0",
         "phpstan/phpstan": "^1.2",
         "phpunit/phpunit": "^9.5.0",
         "spryker/code-sniffer": "^0.17.2",
-        "psalm/phar": "^5",
+        "psalm/phar": "^6",
         "mikey179/vfsstream": "^1.6"
     },
     "suggest": {
         "monolog/monolog": "The recommended logging library to use with Propel."
     },
     "replace": {
-        "propel/propel": "dev-main as 2.0.x-dev"
+        "propel/propel": "dev-main as 2.0.x-dev",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-intl-grapheme": "*",
+        "symfony/polyfill-intl-normalizer": "*"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,139 +31,9 @@ parameters:
 			path: src/Propel/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifier.php
 
 		-
-			message: "#^Access to an undefined property Propel\\\\Generator\\\\Model\\\\ForeignKey\\:\\:\\$isParentChild\\.$#"
-			count: 1
-			path: src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
-
-		-
-			message: "#^Parameter \\#1 \\$unique of method Propel\\\\Generator\\\\Model\\\\Table\\:\\:addUnique\\(\\) expects array\\|Propel\\\\Generator\\\\Model\\\\Unique, Propel\\\\Generator\\\\Model\\\\Index given\\.$#"
-			count: 1
-			path: src/Propel/Generator/Behavior/SyncedTable/TableSyncer.php
-
-		-
-			message: "#^Access to an undefined property Propel\\\\Generator\\\\Model\\\\Table\\:\\:\\$isVersionTable\\.$#"
-			count: 1
-			path: src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
-
-		-
 			message: "#^Variable \\$col might not be defined\\.$#"
 			count: 1
 			path: src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
-
-		-
-			message: "#^Parameter \\#1 \\$v of method Propel\\\\Generator\\\\Builder\\\\DataModelBuilder\\:\\:setGeneratorConfig\\(\\) expects Propel\\\\Generator\\\\Config\\\\GeneratorConfigInterface, \\$this\\(Propel\\\\Generator\\\\Builder\\\\DataModelBuilder\\) given\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/DataModelBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addAddArrayElement\\(\\)\\.$#"
-			count: 2
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addArrayAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addArrayMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addBooleanAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addBooleanMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addDefaultAccessor\\(\\)\\.$#"
-			count: 2
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addDefaultMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addEnumAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addEnumMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addHasArrayElement\\(\\)\\.$#"
-			count: 2
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addJsonAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addJsonMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addLazyLoader\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addLobMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addObjectAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addObjectMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addRemoveArrayElement\\(\\)\\.$#"
-			count: 2
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addSetAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addSetMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addTemporalAccessor\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addTemporalMutator\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
-
-		-
-			message: "#^Variable \\$crossFK might not be defined\\.$#"
-			count: 1
-			path: src/Propel/Generator/Builder/Om/ObjectBuilder.php
 
 		-
 			message: "#^Variable \\$mysqlInvalidDateString might not be defined\\.$#"
@@ -246,11 +116,6 @@ parameters:
 			path: src/Propel/Generator/Util/QuickBuilder.php
 
 		-
-			message: "#^Parameter \\#2 \\$code of class Propel\\\\Generator\\\\Exception\\\\BuildException constructor expects int, null given\\.$#"
-			count: 1
-			path: src/Propel/Generator/Util/QuickBuilder.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -263,21 +128,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:addSelfSelectColumns\\(\\)\\.$#"
 			count: 1
-			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:getTableMap\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\Criterion\\\\AbstractCriterion\\:\\:setIgnoreCase\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\Join\\:\\:getTableMap\\(\\)\\.$#"
-			count: 5
 			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
 
 		-
@@ -346,29 +196,9 @@ parameters:
 			path: src/Propel/Runtime/Collection/ObjectCollection.php
 
 		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:fromArray\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Collection/ObjectCollection.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:getPrimaryKey\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Collection/ObjectCollection.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:save\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/Collection/ObjectCollection.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:getPrimaryKey\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Collection/ObjectCombinationCollection.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:hashCode\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Collection/ObjectCombinationCollection.php
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Connection\\\\ConnectionWrapper\\:\\:getProfiler\\(\\)\\.$#"
@@ -376,19 +206,14 @@ parameters:
 			path: src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
 
 		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:getPrimaryKey\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Formatter/ObjectFormatter.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Map\\\\TableMap\\:\\:populateObject\\(\\)\\.$#"
 			count: 2
 			path: src/Propel/Runtime/Formatter/ObjectFormatter.php
 
 		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:setVirtualColumn\\(\\)\\.$#"
+			message: "#^Propel\\\\Runtime\\\\Collection\\\\ArrayCollection does not accept array\\<string, mixed\\>\\|string\\.$#"
 			count: 1
-			path: src/Propel/Runtime/Formatter/OnDemandFormatter.php
+			path: src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\:\\:setQueryKey\\(\\)\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+<files psalm-version="6.10.1@f9fd6bc117e9ce1e854c2ed6777e7135aaa4966b">
   <file src="src/Propel/Common/Config/ConfigurationManager.php">
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$configSection = &$this->config[$section]]]></code>
@@ -14,50 +14,6 @@
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$existingNames = &self::$insertedAggregationNames[$tableName]]]></code>
     </UnsupportedPropertyReferenceUsage>
-  </file>
-  <file src="src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php">
-    <UndefinedPropertyAssignment>
-      <code><![CDATA[$fk->isParentChild]]></code>
-    </UndefinedPropertyAssignment>
-  </file>
-  <file src="src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php">
-    <UndefinedPropertyAssignment>
-      <code><![CDATA[$syncedTable->isVersionTable]]></code>
-    </UndefinedPropertyAssignment>
-  </file>
-  <file src="src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php">
-    <UndefinedMethod>
-      <code><![CDATA[addAddArrayElement]]></code>
-      <code><![CDATA[addAddArrayElement]]></code>
-      <code><![CDATA[addArrayAccessor]]></code>
-      <code><![CDATA[addArrayMutator]]></code>
-      <code><![CDATA[addBooleanAccessor]]></code>
-      <code><![CDATA[addBooleanMutator]]></code>
-      <code><![CDATA[addDefaultAccessor]]></code>
-      <code><![CDATA[addDefaultAccessor]]></code>
-      <code><![CDATA[addDefaultMutator]]></code>
-      <code><![CDATA[addEnumAccessor]]></code>
-      <code><![CDATA[addEnumMutator]]></code>
-      <code><![CDATA[addHasArrayElement]]></code>
-      <code><![CDATA[addHasArrayElement]]></code>
-      <code><![CDATA[addJsonAccessor]]></code>
-      <code><![CDATA[addJsonMutator]]></code>
-      <code><![CDATA[addLazyLoader]]></code>
-      <code><![CDATA[addLobMutator]]></code>
-      <code><![CDATA[addObjectAccessor]]></code>
-      <code><![CDATA[addObjectMutator]]></code>
-      <code><![CDATA[addRemoveArrayElement]]></code>
-      <code><![CDATA[addRemoveArrayElement]]></code>
-      <code><![CDATA[addSetAccessor]]></code>
-      <code><![CDATA[addSetMutator]]></code>
-      <code><![CDATA[addTemporalAccessor]]></code>
-      <code><![CDATA[addTemporalMutator]]></code>
-    </UndefinedMethod>
-  </file>
-  <file src="src/Propel/Generator/Builder/Om/ObjectBuilder/CrossRelationPartial.php">
-    <DuplicateArrayKey>
-      <code><![CDATA[$additionalGetterNames]]></code>
-    </DuplicateArrayKey>
   </file>
   <file src="src/Propel/Generator/Builder/Util/SchemaReader.php">
     <UnsupportedPropertyReferenceUsage>
@@ -81,17 +37,14 @@
       <code><![CDATA[$this->columnObjects]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
-  <file src="src/Propel/Runtime/ActiveQuery/Criteria.php">
-    <UndefinedFunction>
-      <code><![CDATA[trigger_deprecation('Propel', '2.0', "Method $name should not be used anymore, see DeprecatedCriteriaMethods::$name how to replace it.")]]></code>
-    </UndefinedFunction>
+  <file src="src/Propel/Generator/Reverse/OracleSchemaParser.php">
+    <InvalidArrayOffset>
+      <code><![CDATA[$row[0]]]></code>
+    </InvalidArrayOffset>
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/ModelCriteria.php">
     <UndefinedMethod>
       <code><![CDATA[addSelectColumns]]></code>
-      <code><![CDATA[getTableMap]]></code>
-      <code><![CDATA[getTableMap]]></code>
-      <code><![CDATA[getTableMap]]></code>
     </UndefinedMethod>
   </file>
   <file src="src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php">
@@ -111,6 +64,9 @@
     </UndefinedConstant>
   </file>
   <file src="src/Propel/Runtime/Formatter/AbstractFormatterWithHydration.php">
+    <NonVariableReferenceReturn>
+      <code><![CDATA[$this->alreadyHydratedObjects[$this->class][$mainKey]]]></code>
+    </NonVariableReferenceReturn>
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$arrayToAugment = &$this->alreadyHydratedObjects[$this->class][$mainKey]]]></code>
     </UnsupportedPropertyReferenceUsage>
@@ -120,11 +76,6 @@
       <code><![CDATA[populateObject]]></code>
       <code><![CDATA[populateObject]]></code>
     </UndefinedMethod>
-  </file>
-  <file src="src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php">
-    <UndefinedClass>
-      <code><![CDATA[RotatingFileHandler]]></code>
-    </UndefinedClass>
   </file>
   <file src="src/Propel/Runtime/Util/Profiler.php">
     <InvalidArrayOffset>

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,28 +17,8 @@
 
     <issueHandlers>
         <RedundantConditionGivenDocblockType errorLevel="suppress"/>
-        <DocblockTypeContradiction errorLevel="suppress"/>
         <MissingClosureParamType errorLevel="suppress"/>
         <MissingClosureReturnType errorLevel="suppress"/>
         <PropertyNotSetInConstructor errorLevel="suppress"/>
-        <UnresolvableInclude errorLevel="suppress"/>
-        <ImplementedReturnTypeMismatch errorLevel="suppress"/>
-        <ImplicitToStringCast errorLevel="suppress"/>
-        <UndefinedMagicMethod errorLevel="suppress"/>
-        <UndefinedMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="Symfony\Component\Config\Definition\Builder\TreeBuilder::root"/>
-            </errorLevel>
-        </UndefinedMethod>
-        <!-- Workaround for https://github.com/vimeo/psalm/issues/7026 -->
-        <ReservedWord errorLevel="suppress">
-            <errorLevel type="suppress">
-                <file name="src/Propel/Common/Config/ConfigurationManager.php" />
-                <file name="src/Propel/Common/Config/Loader/YamlFileLoader.php" />
-                <file name="src/Propel/Common/Config/PropelConfiguration.php" />
-                <file name="src/Propel/Generator/Behavior/Validate/ValidateBehavior.php" />
-                <file name="src/Propel/Runtime/Parser/YamlParser.php" />
-            </errorLevel>
-        </ReservedWord>
     </issueHandlers>
 </psalm>

--- a/src/Propel/Common/Config/Loader/IniFileLoader.php
+++ b/src/Propel/Common/Config/Loader/IniFileLoader.php
@@ -38,6 +38,7 @@ class IniFileLoader extends FileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
+    #[\Override]
     public function supports($resource, $type = null): bool
     {
         return static::checkSupports(['ini', 'properties'], $resource);
@@ -54,6 +55,7 @@ class IniFileLoader extends FileLoader
      *
      * @return array The configuration array
      */
+    #[\Override]
     public function load($resource, $type = null): array
     {
         /** @var array<array-key, string|array<array-key, string|array<array-key, string>>>|false $ini */

--- a/src/Propel/Common/Config/Loader/JsonFileLoader.php
+++ b/src/Propel/Common/Config/Loader/JsonFileLoader.php
@@ -27,6 +27,7 @@ class JsonFileLoader extends FileLoader
      *
      * @return array
      */
+    #[\Override]
     public function load($resource, $type = null): array
     {
         $json = file_get_contents($this->getPath($resource));
@@ -53,6 +54,7 @@ class JsonFileLoader extends FileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
+    #[\Override]
     public function supports($resource, $type = null): bool
     {
         return static::checkSupports('json', $resource);

--- a/src/Propel/Common/Config/Loader/PhpFileLoader.php
+++ b/src/Propel/Common/Config/Loader/PhpFileLoader.php
@@ -37,6 +37,7 @@ class PhpFileLoader extends FileLoader
      *
      * @return array
      */
+    #[\Override]
     public function load($resource, $type = null): array
     {
         $path = $this->getPath($resource);
@@ -63,6 +64,7 @@ class PhpFileLoader extends FileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
+    #[\Override]
     public function supports($resource, $type = null): bool
     {
         return static::checkSupports(['php', 'inc'], $resource);

--- a/src/Propel/Common/Config/Loader/XmlFileLoader.php
+++ b/src/Propel/Common/Config/Loader/XmlFileLoader.php
@@ -25,6 +25,7 @@ class XmlFileLoader extends FileLoader
      *
      * @return array
      */
+    #[\Override]
     public function load($resource, $type = null): array
     {
         $content = XmlToArrayConverter::convert($this->getPath($resource));
@@ -40,6 +41,7 @@ class XmlFileLoader extends FileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
+    #[\Override]
     public function supports($resource, $type = null): bool
     {
         return static::checkSupports('xml', $resource);

--- a/src/Propel/Common/Config/Loader/YamlFileLoader.php
+++ b/src/Propel/Common/Config/Loader/YamlFileLoader.php
@@ -30,6 +30,7 @@ class YamlFileLoader extends FileLoader
      *
      * @return array
      */
+    #[\Override]
     public function load($resource, $type = null): array
     {
         $path = $this->locator->locate($resource);
@@ -66,6 +67,7 @@ class YamlFileLoader extends FileLoader
      *
      * @return bool true if this class supports the given resource, false otherwise
      */
+    #[\Override]
     public function supports($resource, $type = null): bool
     {
         return static::checkSupports(['yaml', 'yml'], $resource);

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -25,6 +25,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
+    #[\Override]
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('propel');

--- a/src/Propel/Common/Pluralizer/SimpleEnglishPluralizer.php
+++ b/src/Propel/Common/Pluralizer/SimpleEnglishPluralizer.php
@@ -23,6 +23,7 @@ class SimpleEnglishPluralizer implements PluralizerInterface
      *
      * @return string The plural form of $root (e.g. Authors).
      */
+    #[\Override]
     public function getPluralForm(string $root): string
     {
         return $root . 's';

--- a/src/Propel/Common/Pluralizer/StandardEnglishPluralizer.php
+++ b/src/Propel/Common/Pluralizer/StandardEnglishPluralizer.php
@@ -121,6 +121,7 @@ class StandardEnglishPluralizer implements PluralizerInterface
      *
      * @return string The plural form of $root (e.g. Authors).
      */
+    #[\Override]
     public function getPluralForm(string $root): string
     {
         // save some time in the case that singular and plural are the same

--- a/src/Propel/Generator/Application.php
+++ b/src/Propel/Generator/Application.php
@@ -20,6 +20,7 @@ class Application extends SymfonyApplication
      *
      * @return int
      */
+    #[\Override]
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
         if (extension_loaded('xdebug')) {

--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
@@ -40,6 +40,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return bool
      */
+    #[\Override]
     public function allowMultiple(): bool
     {
         return true;
@@ -52,6 +53,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
@@ -34,6 +34,7 @@ class AggregateColumnRelationBehavior extends Behavior
     /**
      * @return bool
      */
+    #[\Override]
     public function allowMultiple(): bool
     {
         return true;

--- a/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
@@ -91,6 +91,7 @@ class AggregateMultipleColumnsBehavior extends Behavior
      *
      * @return bool
      */
+    #[\Override]
     public function allowMultiple(): bool
     {
         return true;
@@ -143,6 +144,7 @@ class AggregateMultipleColumnsBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $this->validateColumnParameter();

--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -57,6 +57,7 @@ class ArchivableBehavior extends SyncedTableBehavior
      *
      * @return array
      */
+    #[\Override]
     protected function getDefaultParameters(): array
     {
         return [
@@ -83,6 +84,7 @@ class ArchivableBehavior extends SyncedTableBehavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         if ($this->getParameter('archive_class') && $this->getParameter(static::PARAMETER_KEY_SYNCED_TABLE)) {
@@ -99,6 +101,7 @@ class ArchivableBehavior extends SyncedTableBehavior
      *
      * @return void
      */
+    #[\Override]
     public function addTableElements(Table $syncedTable, $tableExistsInSchema): void
     {
         parent::addTableElements($syncedTable, $tableExistsInSchema);
@@ -197,6 +200,7 @@ class ArchivableBehavior extends SyncedTableBehavior
     /**
      * @return $this|\Propel\Generator\Behavior\Archivable\ArchivableBehaviorObjectBuilderModifier
      */
+    #[\Override]
     public function getObjectBuilderModifier()
     {
         if ($this->objectBuilderModifier === null) {
@@ -209,6 +213,7 @@ class ArchivableBehavior extends SyncedTableBehavior
     /**
      * @return $this|\Propel\Generator\Behavior\Archivable\ArchivableBehaviorQueryBuilderModifier
      */
+    #[\Override]
     public function getQueryBuilderModifier()
     {
         if ($this->queryBuilderModifier === null) {

--- a/src/Propel/Generator/Behavior/AutoAddPk/AutoAddPkBehavior.php
+++ b/src/Propel/Generator/Behavior/AutoAddPk/AutoAddPkBehavior.php
@@ -34,6 +34,7 @@ class AutoAddPkBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
@@ -49,6 +50,7 @@ class AutoAddPkBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
@@ -52,6 +52,7 @@ class ConcreteInheritanceBehavior extends Behavior
     /**
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
@@ -37,6 +37,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
     /**
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/ConfigLoad/ConfigLoadBehavior.php
+++ b/src/Propel/Generator/Behavior/ConfigLoad/ConfigLoadBehavior.php
@@ -27,6 +27,7 @@ class ConfigLoadBehavior extends ConfigOperationBehavior
     /**
      * @return string
      */
+    #[\Override]
     protected function getKey(): string
     {
         return $this->getAttribute(static::ATTRIBUTE_KEY_REF);
@@ -37,6 +38,7 @@ class ConfigLoadBehavior extends ConfigOperationBehavior
      *
      * @return void
      */
+    #[\Override]
     protected function apply($behaviorable): void
     {
         $this->validateAttributes();

--- a/src/Propel/Generator/Behavior/ConfigStore/ConfigOperationBehavior.php
+++ b/src/Propel/Generator/Behavior/ConfigStore/ConfigOperationBehavior.php
@@ -18,6 +18,7 @@ abstract class ConfigOperationBehavior extends Behavior
      *
      * @return bool
      */
+    #[\Override]
     public function allowMultiple(): bool
     {
         return true;
@@ -31,6 +32,7 @@ abstract class ConfigOperationBehavior extends Behavior
      /**
       * @return void
       */
+    #[\Override]
     public function modifyDatabase(): void
     {
         $this->apply($this->database);
@@ -39,6 +41,7 @@ abstract class ConfigOperationBehavior extends Behavior
     /**
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $this->apply($this->table);

--- a/src/Propel/Generator/Behavior/ConfigStore/ConfigStoreBehavior.php
+++ b/src/Propel/Generator/Behavior/ConfigStore/ConfigStoreBehavior.php
@@ -32,6 +32,7 @@ class ConfigStoreBehavior extends ConfigOperationBehavior
      *
      * @return bool
      */
+    #[\Override]
     public function allowMultiple(): bool
     {
         return true;
@@ -42,6 +43,7 @@ class ConfigStoreBehavior extends ConfigOperationBehavior
      *
      * @return void
      */
+    #[\Override]
     protected function apply($behaviorable): void
     {
         if ($this->wasApplied) {
@@ -55,6 +57,7 @@ class ConfigStoreBehavior extends ConfigOperationBehavior
     /**
      * @return string
      */
+    #[\Override]
     protected function getKey(): string
     {
         return $this->getAttribute('id');

--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -63,6 +63,7 @@ class DelegateBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -69,6 +69,7 @@ class I18nBehavior extends Behavior
     /**
      * @return void
      */
+    #[\Override]
     public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
@@ -172,6 +173,7 @@ class I18nBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\I18n\I18nBehaviorObjectBuilderModifier
      */
+    #[\Override]
     public function getObjectBuilderModifier()
     {
         if ($this->objectBuilderModifier === null) {
@@ -184,6 +186,7 @@ class I18nBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\I18n\I18nBehaviorQueryBuilderModifier
      */
+    #[\Override]
     public function getQueryBuilderModifier()
     {
         if ($this->queryBuilderModifier === null) {
@@ -208,6 +211,7 @@ class I18nBehavior extends Behavior
     /**
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $this->addI18nTable();

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehavior.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehavior.php
@@ -47,6 +47,7 @@ class NestedSetBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();
@@ -83,6 +84,7 @@ class NestedSetBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\NestedSet\NestedSetBehaviorObjectBuilderModifier
      */
+    #[\Override]
     public function getObjectBuilderModifier()
     {
         if ($this->objectBuilderModifier === null) {
@@ -95,6 +97,7 @@ class NestedSetBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\NestedSet\NestedSetBehaviorQueryBuilderModifier
      */
+    #[\Override]
     public function getQueryBuilderModifier()
     {
         if ($this->queryBuilderModifier === null) {

--- a/src/Propel/Generator/Behavior/OutputGroup/OutputGroupBehavior.php
+++ b/src/Propel/Generator/Behavior/OutputGroup/OutputGroupBehavior.php
@@ -69,6 +69,7 @@ class OutputGroupBehavior extends Behavior
      *
      * @return $this|\Propel\Generator\Behavior\OutputGroup\OgObjectModifier
      */
+    #[\Override]
     public function getObjectBuilderModifier()
     {
         if ($this->objectModifier === null) {
@@ -83,6 +84,7 @@ class OutputGroupBehavior extends Behavior
      *
      * @return $this|\Propel\Generator\Behavior\OutputGroup\OgTableMapModifier
      */
+    #[\Override]
     public function getTableMapBuilderModifier()
     {
         if ($this->tableModifier === null) {
@@ -97,6 +99,7 @@ class OutputGroupBehavior extends Behavior
      *
      * @return $this|\Propel\Generator\Behavior\OutputGroup\OgQueryModifier
      */
+    #[\Override]
     public function getQueryBuilderModifier()
     {
         if ($this->queryModifier === null) {
@@ -115,6 +118,7 @@ class OutputGroupBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -45,6 +45,7 @@ class SluggableBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
@@ -53,6 +53,7 @@ class SortableBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();
@@ -85,6 +86,7 @@ class SortableBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\Sortable\SortableBehaviorObjectBuilderModifier
      */
+    #[\Override]
     public function getObjectBuilderModifier()
     {
         if ($this->objectBuilderModifier === null) {
@@ -97,6 +99,7 @@ class SortableBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\Sortable\SortableBehaviorQueryBuilderModifier
      */
+    #[\Override]
     public function getQueryBuilderModifier()
     {
         if ($this->queryBuilderModifier === null) {
@@ -109,6 +112,7 @@ class SortableBehavior extends Behavior
     /**
      * @return $this|\Propel\Generator\Behavior\Sortable\SortableBehaviorTableMapBuilderModifier
      */
+    #[\Override]
     public function getTableMapBuilderModifier()
     {
         if ($this->tableMapBuilderModifier === null) {
@@ -204,6 +208,7 @@ class SortableBehavior extends Behavior
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function addParameter(array $parameter): void
     {
         if ($parameter['name'] === 'scope_column') {

--- a/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehavior.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehavior.php
@@ -45,6 +45,7 @@ class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         parent::setupObject();
@@ -64,6 +65,7 @@ class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
     /**
      * @return string
      */
+    #[\Override]
     public function resolveSyncedTableName(): string
     {
         return $this->getSyncedTableName()
@@ -75,6 +77,7 @@ class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
      *
      * @return void
      */
+    #[\Override]
     public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
@@ -104,6 +107,7 @@ class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         if ($this->omitOnSkipSql() && $this->table->isSkipSql()) {
@@ -153,6 +157,7 @@ class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
      *
      * @return void
      */
+    #[\Override]
     public function addTableElements(Table $syncedTable, bool $tableExistsInSchema): void
     {
         // base implementation does nothing
@@ -203,6 +208,7 @@ class SyncedTableBehavior extends SyncedTableBehaviorDeclaration
     /**
      * @return string
      */
+    #[\Override]
     public function getColumnPrefix(): string
     {
         $val = $this->useColumnPrefix();

--- a/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehaviorDeclaration.php
+++ b/src/Propel/Generator/Behavior/SyncedTable/SyncedTableBehaviorDeclaration.php
@@ -146,6 +146,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return string
      */
+    #[\Override]
     public function getDefaultSyncedTableSuffix(): string
     {
         return static::DEFAULT_SYNCED_TABLE_SUFFIX;
@@ -184,6 +185,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return array
      */
+    #[\Override]
     public function getTableAttributes(): array
     {
         $val = $this->parameters[static::PARAMETER_KEY_TABLE_ATTRIBUTES] ?? null;
@@ -194,6 +196,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return string|null
      */
+    #[\Override]
     public function getSyncedTablePhpName(): ?string
     {
         return $this->getParameter(static::PARAMETER_KEY_SYNCED_PHPNAME);
@@ -202,6 +205,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return string|null
      */
+    #[\Override]
     public function addPkAs(): ?string
     {
         $val = $this->getParameterTrueOrValue(static::PARAMETER_KEY_ADD_PK, false);
@@ -212,6 +216,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return array|null
      */
+    #[\Override]
     public function getColmns(): ?array
     {
         return $this->parameters[static::PARAMETER_KEY_COLUMNS] ?? [];
@@ -220,6 +225,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return array
      */
+    #[\Override]
     public function getForeignKeys(): array
     {
         return $this->parameters[static::PARAMETER_KEY_FOREIGN_KEYS] ?? [];
@@ -228,6 +234,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return bool
      */
+    #[\Override]
     public function isSync(): bool
     {
         return $this->getParameterBool(static::PARAMETER_KEY_SYNC, false);
@@ -244,6 +251,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return bool
      */
+    #[\Override]
     public function isSyncIndexes(): bool
     {
         return $this->getParameterBool(static::PARAMETER_KEY_SYNC_INDEXES, false);
@@ -252,6 +260,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return string|null
      */
+    #[\Override]
     public function getSyncUniqueIndexAs(): ?string
     {
         return $this->getParameter(static::PARAMETER_KEY_SYNC_UNIQUE_AS);
@@ -260,6 +269,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return array|null
      */
+    #[\Override]
     public function getRelationAttributes(): ?array
     {
         /** @var array<array>|string|null $val */
@@ -284,6 +294,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return bool
      */
+    #[\Override]
     public function isInheritForeignKeyRelations(): bool
     {
         return $this->getParameterBool(static::PARAMETER_KEY_INHERIT_FOREIGN_KEY_RELATIONS, false);
@@ -292,6 +303,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return bool
      */
+    #[\Override]
     public function isInheritForeignKeyConstraints(): bool
     {
         return $this->getParameterBool(static::PARAMETER_KEY_INHERIT_FOREIGN_KEY_CONSTRAINTS, false);
@@ -300,6 +312,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return array
      */
+    #[\Override]
     public function getIgnoredColumnNames(): array
     {
         return $this->getParameterCsv(static::PARAMETER_KEY_IGNORE_COLUMNS, []);
@@ -318,6 +331,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return bool
      */
+    #[\Override]
     public function isSyncPkOnly(): bool
     {
         return $this->getParameterBool(static::PARAMETER_KEY_SYNC_PK_ONLY, false);
@@ -336,6 +350,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
     /**
      * @return bool
      */
+    #[\Override]
     public function inheritSkipSql(): bool
     {
         return $this->onSkipSql() === 'inherit';
@@ -354,6 +369,7 @@ abstract class SyncedTableBehaviorDeclaration extends BehaviorWithParameterAcces
      *
      * @return array|null
      */
+    #[\Override]
     public function getTableInheritance()
     {
         $val = $this->parameters[static::PARAMETER_KEY_INHERIT_FROM_TABLE] ?? null;

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -50,6 +50,7 @@ class TimestampableBehavior extends Behavior
      *
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $table = $this->getTable();

--- a/src/Propel/Generator/Behavior/Util/BehaviorWithParameterAccess.php
+++ b/src/Propel/Generator/Behavior/Util/BehaviorWithParameterAccess.php
@@ -19,6 +19,7 @@ abstract class BehaviorWithParameterAccess extends Behavior
      *
      * @return string|null
      */
+    #[\Override]
     public function getParameter(string $name, ?string $defaultValue = null): ?string
     {
         $val = $this->parameters[$name] ?? null;

--- a/src/Propel/Generator/Behavior/Util/InsertCodeBehavior.php
+++ b/src/Propel/Generator/Behavior/Util/InsertCodeBehavior.php
@@ -65,6 +65,7 @@ class InsertCodeBehavior extends Behavior
      *
      * @return bool
      */
+    #[\Override]
     public function allowMultiple(): bool
     {
         return true;

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
@@ -79,6 +79,7 @@ class VersionableBehavior extends SyncedTableBehavior
      *
      * @return array
      */
+    #[\Override]
     protected function getDefaultParameters(): array
     {
         return [
@@ -115,6 +116,7 @@ class VersionableBehavior extends SyncedTableBehavior
      *
      * @return void
      */
+    #[\Override]
     protected function addBehaviorToTable(Table $table): void
     {
         if (in_array($table, $this->versionTables)) {
@@ -127,6 +129,7 @@ class VersionableBehavior extends SyncedTableBehavior
     /**
      * @return string|null
      */
+    #[\Override]
     public function getSyncedTablePhpName(): ?string
     {
         // required for BC
@@ -136,6 +139,7 @@ class VersionableBehavior extends SyncedTableBehavior
     /**
      * @return void
      */
+    #[\Override]
     public function modifyTable(): void
     {
         $this->addColumnsToSourceTable();
@@ -182,6 +186,7 @@ class VersionableBehavior extends SyncedTableBehavior
      *
      * @return void
      */
+    #[\Override]
     public function addTableElements(Table $syncedTable, bool $tableExistsInSchema): void
     {
         parent::addTableElements($syncedTable, $tableExistsInSchema);
@@ -292,6 +297,7 @@ class VersionableBehavior extends SyncedTableBehavior
     /**
      * @return $this|\Propel\Generator\Behavior\Versionable\VersionableBehaviorObjectBuilderModifier
      */
+    #[\Override]
     public function getObjectBuilderModifier()
     {
         if ($this->objectBuilderModifier === null) {
@@ -304,6 +310,7 @@ class VersionableBehavior extends SyncedTableBehavior
     /**
      * @return $this|\Propel\Generator\Behavior\Versionable\VersionableBehaviorQueryBuilderModifier
      */
+    #[\Override]
     public function getQueryBuilderModifier()
     {
         if ($this->queryBuilderModifier === null) {

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -190,6 +190,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return bool
      */
+    #[\Override]
     public function hasBehaviorModifier(string $hookName, string $modifier = ''): bool
     {
          return parent::hasBehaviorModifier($hookName, 'ObjectBuilderModifier');

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -8,8 +8,6 @@
 
 namespace Propel\Generator\Builder\Om;
 
-use Propel\Generator\Model\PropelTypes;
-
 /**
  * Base class for object-building classes.
  *
@@ -21,105 +19,6 @@ use Propel\Generator\Model\PropelTypes;
  */
 abstract class AbstractObjectBuilder extends AbstractOMBuilder
 {
-    /**
-     * Adds the getter methods for the column values.
-     * This is here because it is probably generic enough to apply to templates being generated
-     * in different PHP versions.
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
-     */
-    protected function addColumnAccessorMethods(string &$script): void
-    {
-        $table = $this->getTable();
-
-        foreach ($table->getColumns() as $col) {
-            $type = $col->getType();
-            // if they're not using the DateTime class then we will generate "compatibility" accessor method
-            if (
-                $type === PropelTypes::DATE
-                || $type === PropelTypes::DATETIME
-                || $type === PropelTypes::TIME
-                || $type === PropelTypes::TIMESTAMP
-            ) {
-                $this->addTemporalAccessor($script, $col);
-            } elseif ($type === PropelTypes::OBJECT) {
-                $this->addObjectAccessor($script, $col);
-            } elseif ($type === PropelTypes::PHP_ARRAY) {
-                $this->addArrayAccessor($script, $col);
-                if ($col->isNamePlural()) {
-                    $this->addHasArrayElement($script, $col);
-                }
-            } elseif ($type === PropelTypes::JSON) {
-                $this->addJsonAccessor($script, $col);
-            } elseif ($col->isEnumType()) {
-                $this->addEnumAccessor($script, $col);
-            } elseif ($col->isSetType()) {
-                $this->addSetAccessor($script, $col);
-                if ($col->isNamePlural()) {
-                    $this->addHasArrayElement($script, $col);
-                }
-            } elseif ($col->isBooleanType()) {
-                $this->addDefaultAccessor($script, $col);
-                $this->addBooleanAccessor($script, $col);
-            } else {
-                $this->addDefaultAccessor($script, $col);
-            }
-
-            if ($col->isLazyLoad()) {
-                $this->addLazyLoader($script, $col);
-            }
-        }
-    }
-
-    /**
-     * Adds the mutator (setter) methods for setting column values.
-     * This is here because it is probably generic enough to apply to templates being generated
-     * in different PHP versions.
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
-     */
-    protected function addColumnMutatorMethods(string &$script): void
-    {
-        foreach ($this->getTable()->getColumns() as $col) {
-            if ($col->getType() === PropelTypes::OBJECT) {
-                $this->addObjectMutator($script, $col);
-            } elseif ($col->isLobType()) {
-                $this->addLobMutator($script, $col);
-            } elseif (
-                $col->getType() === PropelTypes::DATE
-                || $col->getType() === PropelTypes::DATETIME
-                || $col->getType() === PropelTypes::TIME
-                || $col->getType() === PropelTypes::TIMESTAMP
-            ) {
-                $this->addTemporalMutator($script, $col);
-            } elseif ($col->getType() === PropelTypes::PHP_ARRAY) {
-                $this->addArrayMutator($script, $col);
-                if ($col->isNamePlural()) {
-                    $this->addAddArrayElement($script, $col);
-                    $this->addRemoveArrayElement($script, $col);
-                }
-            } elseif ($col->getType() === PropelTypes::JSON) {
-                $this->addJsonMutator($script, $col);
-            } elseif ($col->isEnumType()) {
-                $this->addEnumMutator($script, $col);
-            } elseif ($col->isSetType()) {
-                $this->addSetMutator($script, $col);
-                if ($col->isNamePlural()) {
-                    $this->addAddArrayElement($script, $col);
-                    $this->addRemoveArrayElement($script, $col);
-                }
-            } elseif ($col->isBooleanType()) {
-                $this->addBooleanMutator($script, $col);
-            } else {
-                $this->addDefaultMutator($script, $col);
-            }
-        }
-    }
-
     /**
      * Gets the baseClass path if specified for table/db.
      *

--- a/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
@@ -23,6 +23,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName();
@@ -35,6 +36,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -80,6 +82,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
     }
@@ -91,6 +94,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -23,6 +23,7 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName() . 'Query';
@@ -35,6 +36,7 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -85,6 +87,7 @@ class $className extends $baseClassName
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
     }
@@ -96,6 +99,7 @@ class $className extends $baseClassName
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "
@@ -112,6 +116,7 @@ class $className extends $baseClassName
      *
      * @return bool
      */
+    #[\Override]
     public function hasBehaviorModifier(string $hookName, string $modifier = ''): bool
     {
          return parent::hasBehaviorModifier($hookName, 'QueryBuilderModifier');

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
@@ -33,6 +33,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getChild()->getClassName() . 'Query';
@@ -43,6 +44,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string|null
      */
+    #[\Override]
     public function getPackage(): ?string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage());
@@ -83,6 +85,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -132,6 +135,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
     }
@@ -143,6 +147,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "

--- a/src/Propel/Generator/Builder/Om/InterfaceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/InterfaceBuilder.php
@@ -23,6 +23,7 @@ class InterfaceBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return ClassTools::classname($this->getInterface());
@@ -35,6 +36,7 @@ class InterfaceBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -77,6 +79,7 @@ interface " . $this->getUnqualifiedClassName() . "
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         // there is no class body
@@ -89,6 +92,7 @@ interface " . $this->getUnqualifiedClassName() . "
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "

--- a/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
@@ -34,6 +34,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getChild()->getClassName();
@@ -44,6 +45,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return string|null
      */
+    #[\Override]
     public function getPackage(): ?string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage());
@@ -108,6 +110,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         if ($this->getChild()->getAncestor()) {
@@ -164,6 +167,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $this->getParentClass
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         $child = $this->getChild();
@@ -192,6 +196,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $this->getParentClass
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -67,6 +67,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function init(Table $table, ?GeneratorConfigInterface $generatorConfig): void
     {
         parent::init($table, $generatorConfig);
@@ -97,6 +98,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getPackage(): string
     {
         return parent::getPackage() . '.Base';
@@ -109,6 +111,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string|null
      */
+    #[\Override]
     public function getNamespace(): ?string
     {
         $namespace = parent::getNamespace();
@@ -135,6 +138,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getStubObjectBuilder()->getUnprefixedClassName();
@@ -152,6 +156,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function validateModel(): void
     {
         parent::validateModel();
@@ -316,6 +321,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -374,6 +380,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         $this->declareClassFromBuilder($this->getStubObjectBuilder());
@@ -499,6 +506,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -834,6 +834,105 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     }
 
     /**
+     * Adds the getter methods for the column values.
+     * This is here because it is probably generic enough to apply to templates being generated
+     * in different PHP versions.
+     *
+     * @param string $script The script will be modified in this method.
+     *
+     * @return void
+     */
+    protected function addColumnAccessorMethods(string &$script): void
+    {
+        $table = $this->getTable();
+
+        foreach ($table->getColumns() as $col) {
+            $type = $col->getType();
+            // if they're not using the DateTime class then we will generate "compatibility" accessor method
+            if (
+                $type === PropelTypes::DATE
+                || $type === PropelTypes::DATETIME
+                || $type === PropelTypes::TIME
+                || $type === PropelTypes::TIMESTAMP
+            ) {
+                $this->addTemporalAccessor($script, $col);
+            } elseif ($type === PropelTypes::OBJECT) {
+                $this->addObjectAccessor($script, $col);
+            } elseif ($type === PropelTypes::PHP_ARRAY) {
+                $this->addArrayAccessor($script, $col);
+                if ($col->isNamePlural()) {
+                    $this->addHasArrayElement($script, $col);
+                }
+            } elseif ($type === PropelTypes::JSON) {
+                $this->addJsonAccessor($script, $col);
+            } elseif ($col->isEnumType()) {
+                $this->addEnumAccessor($script, $col);
+            } elseif ($col->isSetType()) {
+                $this->addSetAccessor($script, $col);
+                if ($col->isNamePlural()) {
+                    $this->addHasArrayElement($script, $col);
+                }
+            } elseif ($col->isBooleanType()) {
+                $this->addDefaultAccessor($script, $col);
+                $this->addBooleanAccessor($script, $col);
+            } else {
+                $this->addDefaultAccessor($script, $col);
+            }
+
+            if ($col->isLazyLoad()) {
+                $this->addLazyLoader($script, $col);
+            }
+        }
+    }
+
+    /**
+     * Adds the mutator (setter) methods for setting column values.
+     * This is here because it is probably generic enough to apply to templates being generated
+     * in different PHP versions.
+     *
+     * @param string $script The script will be modified in this method.
+     *
+     * @return void
+     */
+    protected function addColumnMutatorMethods(string &$script): void
+    {
+        foreach ($this->getTable()->getColumns() as $col) {
+            if ($col->getType() === PropelTypes::OBJECT) {
+                $this->addObjectMutator($script, $col);
+            } elseif ($col->isLobType()) {
+                $this->addLobMutator($script, $col);
+            } elseif (
+                $col->getType() === PropelTypes::DATE
+                || $col->getType() === PropelTypes::DATETIME
+                || $col->getType() === PropelTypes::TIME
+                || $col->getType() === PropelTypes::TIMESTAMP
+            ) {
+                $this->addTemporalMutator($script, $col);
+            } elseif ($col->getType() === PropelTypes::PHP_ARRAY) {
+                $this->addArrayMutator($script, $col);
+                if ($col->isNamePlural()) {
+                    $this->addAddArrayElement($script, $col);
+                    $this->addRemoveArrayElement($script, $col);
+                }
+            } elseif ($col->getType() === PropelTypes::JSON) {
+                $this->addJsonMutator($script, $col);
+            } elseif ($col->isEnumType()) {
+                $this->addEnumMutator($script, $col);
+            } elseif ($col->isSetType()) {
+                $this->addSetMutator($script, $col);
+                if ($col->isNamePlural()) {
+                    $this->addAddArrayElement($script, $col);
+                    $this->addRemoveArrayElement($script, $col);
+                }
+            } elseif ($col->isBooleanType()) {
+                $this->addBooleanMutator($script, $col);
+            } else {
+                $this->addDefaultMutator($script, $col);
+            }
+        }
+    }
+
+    /**
      * Adds the base object hook functions.
      *
      * @param string $script

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractIncomingRelationCode.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractIncomingRelationCode.php
@@ -118,6 +118,7 @@ abstract class AbstractIncomingRelationCode extends AbstractRelationCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addOnReloadCode(string &$script): void
     {
         $attributeName = $this->getAttributeName();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractManyToManyCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/AbstractManyToManyCodeProducer.php
@@ -51,6 +51,7 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      *
      * @return void
      */
+    #[\Override]
     protected function init(Table $table, ?GeneratorConfigInterface $generatorConfig): void
     {
         parent::init($table, $generatorConfig);
@@ -91,6 +92,7 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      *
      * @return void
      */
+    #[\Override]
     public function addMethods(string &$script): void
     {
         $this->registerTargetClasses();
@@ -140,6 +142,7 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      *
      * @return void
      */
+    #[\Override]
     abstract public function addDeleteScheduledItemsCode(string &$script): void;
 
     /**
@@ -287,6 +290,7 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      *
      * @return void
      */
+    #[\Override]
     public function addAttributes(string &$script): void
     {
         $attributeName = '$' . $this->names->getAttributeWithCollectionName();
@@ -359,6 +363,7 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      *
      * @return string
      */
+    #[\Override]
     public function addClearReferencesCode(string &$script): string
     {
         $varName = $this->names->getAttributeWithCollectionName();
@@ -523,6 +528,7 @@ abstract class AbstractManyToManyCodeProducer extends AbstractRelationCodeProduc
      *
      * @return void
      */
+    #[\Override]
     public function addOnReloadCode(string &$script): void
     {
         $attributeName = $this->names->getAttributeWithCollectionName();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/FkRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/FkRelationCodeProducer.php
@@ -55,6 +55,7 @@ class FkRelationCodeProducer extends AbstractRelationCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addMethods(string &$script): void
     {
         $this->registerTargetClasses();
@@ -70,6 +71,7 @@ class FkRelationCodeProducer extends AbstractRelationCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addAttributes(string &$script): void
     {
         $className = $this->getClassNameFromTable($this->relation->getForeignTable());
@@ -88,6 +90,7 @@ class FkRelationCodeProducer extends AbstractRelationCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addOnReloadCode(string &$script): void
     {
         $varName = $this->getAttributeName();
@@ -100,6 +103,7 @@ class FkRelationCodeProducer extends AbstractRelationCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addDeleteScheduledItemsCode(string &$script): void
     {
         $attributeName = $this->getAttributeName();
@@ -120,6 +124,7 @@ class FkRelationCodeProducer extends AbstractRelationCodeProducer
      *
      * @return string
      */
+    #[\Override]
     public function addClearReferencesCode(string &$script): string
     {
         $varName = $this->getAttributeName();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/ManyToManyRelationCodeProducer.php
@@ -33,6 +33,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return array{string, string}
      */
+    #[\Override]
     protected function resolveObjectCollectionClassNameAndType(?Table $table = null): array
     {
         return parent::resolveObjectCollectionClassNameAndType($table ?? $this->getFkToTarget()->getForeignTable());
@@ -43,6 +44,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addScheduledForDeletionAttribute(string &$script): void
     {
         $refFK = $this->crossRelation->getIncomingForeignKey();
@@ -60,6 +62,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function addInit(string &$script): void
     {
         $fk = $this->getFkToTarget();
@@ -78,6 +81,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function addCreateQuery(string &$script): void
     {
         // no addCreateQuery.
@@ -90,6 +94,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return array<string>
      */
+    #[\Override]
     public function reserveNamesForGetters(): array
     {
         $targetIdentifierSingular = $this->names->getTargetIdentifier(false);
@@ -102,6 +107,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function addGetters(string &$script): void
     {
         $sourceIdentifierSingular = $this->names->getSourceIdentifier(false);
@@ -174,6 +180,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
     /**
      * @return bool
      */
+    #[\Override]
     protected function setterItemIsArray(): bool
     {
         return false;
@@ -184,6 +191,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addDeleteScheduledItemsCode(string &$script): void
     {
         $scheduledForDeletionVarName = $this->names->getAttributeScheduledForDeletionName();
@@ -242,6 +250,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
     /**
      * @return string
      */
+    #[\Override]
     protected function buildAdditionalCountMethods(): string
     {
         return '';
@@ -252,6 +261,7 @@ class ManyToManyRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function buildDoAdd(string &$script): void
     {
         $middleTableModelClass = $this->names->getMiddleTableModelClass();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/OneToManyRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/OneToManyRelationCodeProducer.php
@@ -20,6 +20,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      *
      * @return string
      */
+    #[\Override]
     public function getAttributeName(): string
     {
         return 'coll' . $this->relation->getIdentifierReversed($this->getPluralizer());
@@ -30,6 +31,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      *
      * @return void
      */
+    #[\Override]
     public function addMethods(string &$script): void
     {
         $this->registerTargetClasses();
@@ -55,6 +57,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      *
      * @return void
      */
+    #[\Override]
     public function addAttributes(string &$script): void
     {
         $className = $this->getClassNameFromTable($this->relation->getTable());
@@ -78,6 +81,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      *
      * @return void
      */
+    #[\Override]
     public function addDeleteScheduledItemsCode(string &$script): void
     {
         $this->addScheduledForDeletion($script);
@@ -135,6 +139,7 @@ class OneToManyRelationCodeProducer extends AbstractIncomingRelationCode
      *
      * @return string
      */
+    #[\Override]
     public function addClearReferencesCode(string &$script): string
     {
         $attributeName = $this->getAttributeName();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/RelationFromOneCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/RelationFromOneCodeProducer.php
@@ -18,6 +18,7 @@ class RelationFromOneCodeProducer extends AbstractIncomingRelationCode
      *
      * @return string
      */
+    #[\Override]
     public function getAttributeName(): string
     {
         return 'single' . $this->relation->getIdentifierReversed();
@@ -28,6 +29,7 @@ class RelationFromOneCodeProducer extends AbstractIncomingRelationCode
      *
      * @return void
      */
+    #[\Override]
     public function addMethods(string &$script): void
     {
         $this->registerTargetClasses();
@@ -45,6 +47,7 @@ class RelationFromOneCodeProducer extends AbstractIncomingRelationCode
      *
      * @return void
      */
+    #[\Override]
     public function addAttributes(string &$script): void
     {
         $className = $this->getClassNameFromTable($this->relation->getTable());
@@ -62,6 +65,7 @@ class RelationFromOneCodeProducer extends AbstractIncomingRelationCode
      *
      * @return void
      */
+    #[\Override]
     public function addDeleteScheduledItemsCode(string &$script): void
     {
         $varName = $this->getAttributeName();
@@ -78,6 +82,7 @@ class RelationFromOneCodeProducer extends AbstractIncomingRelationCode
      *
      * @return string
      */
+    #[\Override]
     public function addClearReferencesCode(string &$script): string
     {
         $varName = $this->getAttributeName();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryRelationCodeProducer.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder/RelationCodeProducer/TernaryRelationCodeProducer.php
@@ -29,6 +29,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
     /**
      * @return void
      */
+    #[\Override]
     public function registerTargetClasses(): void
     {
         parent::registerTargetClasses();
@@ -42,6 +43,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function addInit(string &$script): void
     {
         $script .= $this->buildInitCode('ObjectCombinationCollection', null, null);
@@ -52,6 +54,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function addCreateQuery(string &$script): void
     {
         foreach ($this->crossRelation->getCrossForeignKeys() as $fk) {
@@ -128,6 +131,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return string
      */
+    #[\Override]
     public function addClearReferencesCode(string &$script): string
     {
         $varName = $this->names->getAttributeWithCollectionName();
@@ -149,6 +153,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return array<string>
      */
+    #[\Override]
     public function reserveNamesForGetters(): array
     {
         $targetIdentifierSingular = $this->names->getTargetIdentifier(false);
@@ -162,6 +167,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function addGetters(string &$script): void
     {
         [$objectCollectionClassName, $objectCollectionType] = $this->resolveObjectCollectionClassNameAndType();
@@ -306,6 +312,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
     /**
      * @return bool
      */
+    #[\Override]
     protected function setterItemIsArray(): bool
     {
         return true;
@@ -316,6 +323,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return array{string, string}
      */
+    #[\Override]
     protected function resolveObjectCollectionClassNameAndType(?Table $table = null): array
     {
         if ($table) {
@@ -334,6 +342,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     public function addDeleteScheduledItemsCode(string &$script): void
     {
         $scheduledForDeletionVarName = $this->names->getAttributeScheduledForDeletionName();
@@ -414,6 +423,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
     /**
      * @return string
      */
+    #[\Override]
     protected function buildAdditionalCountMethods(): string
     {
         $methods = array_map([$this, 'buildCountRelationMethod'], $this->crossRelation->getCrossForeignKeys());
@@ -458,6 +468,7 @@ class TernaryRelationCodeProducer extends AbstractManyToManyCodeProducer
      *
      * @return void
      */
+    #[\Override]
     protected function buildDoAdd(string &$script): void
     {
         $targetIdentifierSingular = $this->names->getTargetIdentifier(false);

--- a/src/Propel/Generator/Builder/Om/ObjectCollectionBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectCollectionBuilder.php
@@ -36,6 +36,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function init(Table $table, ?GeneratorConfigInterface $generatorConfig): void
     {
         parent::init($table, $generatorConfig);
@@ -58,6 +59,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getPackage(): string
     {
         return parent::getPackage() . '.Base.Collection';
@@ -66,6 +68,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
     /**
      * @return string|null
      */
+    #[\Override]
     public function getNamespace(): ?string
     {
         $namespace = parent::getNamespace();
@@ -84,6 +87,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
     /**
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName() . 'Collection';
@@ -119,6 +123,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $this->registerClasses(); // does not work on init
@@ -141,6 +146,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         $script .= $this->renderTemplate('objectCollectionClassBody', [
@@ -153,6 +159,7 @@ class ObjectCollectionBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "\n}\n";

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -32,6 +32,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getPackage(): string
     {
         return parent::getPackage() . '.Base';
@@ -42,6 +43,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return string|null
      */
+    #[\Override]
     public function getNamespace(): ?string
     {
         $namespace = parent::getNamespace();
@@ -54,6 +56,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getStubQueryBuilder()->getUnprefixedClassName();
@@ -86,6 +89,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -153,6 +157,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         $table = $this->getTable();
@@ -315,6 +320,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "
@@ -1973,6 +1979,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return bool
      */
+    #[\Override]
     public function hasBehaviorModifier(string $hookName, string $modifier = ''): bool
     {
         return parent::hasBehaviorModifier($hookName, 'QueryBuilderModifier');

--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -34,6 +34,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getNewStubQueryInheritanceBuilder($this->getChild())->getUnprefixedClassName();
@@ -44,6 +45,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getPackage(): string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage()) . '.Base';
@@ -54,6 +56,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string|null
      */
+    #[\Override]
     public function getNamespace(): ?string
     {
         $namespace = parent::getNamespace();
@@ -122,6 +125,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -168,6 +172,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         $this->declareClassFromBuilder($this->getTableMapBuilder());
@@ -335,6 +340,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -24,6 +24,7 @@ class TableMapBuilder extends AbstractOMBuilder
  /**
   * @return void
   */
+    #[\Override]
     protected function validateModel(): void
     {
         parent::validateModel();
@@ -43,6 +44,7 @@ class TableMapBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getPackage(): string
     {
         return parent::getPackage() . '.Map';
@@ -51,6 +53,7 @@ class TableMapBuilder extends AbstractOMBuilder
     /**
      * @return string|null
      */
+    #[\Override]
     public function getNamespace(): ?string
     {
         $namespace = parent::getNamespace();
@@ -79,6 +82,7 @@ class TableMapBuilder extends AbstractOMBuilder
      *
      * @return string
      */
+    #[\Override]
     public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName() . 'TableMap';
@@ -91,6 +95,7 @@ class TableMapBuilder extends AbstractOMBuilder
      *
      * @return void
      */
+    #[\Override]
     protected function addClassOpen(string &$script): void
     {
         $table = $this->getTable();
@@ -133,6 +138,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
+    #[\Override]
     protected function addClassBody(string &$script): void
     {
         $table = $this->getTable();
@@ -523,6 +529,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
+    #[\Override]
     protected function addClassClose(string &$script): void
     {
         $script .= "
@@ -879,6 +886,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return bool
      */
+    #[\Override]
     public function hasBehaviorModifier(string $hookName, string $modifier = ''): bool
     {
         return parent::hasBehaviorModifier($hookName, 'TableMapBuilderModifier');

--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -47,6 +47,7 @@ abstract class AbstractCommand extends Command
      *
      * @return void
      */
+    #[\Override]
     protected function configure()
     {
         $this

--- a/src/Propel/Generator/Command/ConfigConvertCommand.php
+++ b/src/Propel/Generator/Command/ConfigConvertCommand.php
@@ -33,6 +33,7 @@ class ConfigConvertCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         $this
@@ -50,6 +51,7 @@ class ConfigConvertCommand extends AbstractCommand
      *
      * @throws \RuntimeException
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configManager = new ConfigurationManager($input->getOption('config-dir'));

--- a/src/Propel/Generator/Command/DataDictionaryExportCommand.php
+++ b/src/Propel/Generator/Command/DataDictionaryExportCommand.php
@@ -39,6 +39,7 @@ class DataDictionaryExportCommand extends AbstractCommand
      *
      * @return void
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -63,6 +64,7 @@ class DataDictionaryExportCommand extends AbstractCommand
      *
      * @return int
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/DatabaseReverseCommand.php
+++ b/src/Propel/Generator/Command/DatabaseReverseCommand.php
@@ -38,6 +38,7 @@ class DatabaseReverseCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -61,6 +62,7 @@ class DatabaseReverseCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/GraphvizGenerateCommand.php
+++ b/src/Propel/Generator/Command/GraphvizGenerateCommand.php
@@ -26,6 +26,7 @@ class GraphvizGenerateCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -41,6 +42,7 @@ class GraphvizGenerateCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -47,6 +47,7 @@ class InitCommand extends AbstractCommand
     /**
      * @return void
      */
+    #[\Override]
     protected function configure(): void
     {
         parent::configure();
@@ -62,6 +63,7 @@ class InitCommand extends AbstractCommand
      *
      * @return int
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $consoleHelper = new ConsoleHelper($input, $output);

--- a/src/Propel/Generator/Command/MigrationCreateCommand.php
+++ b/src/Propel/Generator/Command/MigrationCreateCommand.php
@@ -22,6 +22,7 @@ class MigrationCreateCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -40,6 +41,7 @@ class MigrationCreateCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/MigrationDiffCommand.php
+++ b/src/Propel/Generator/Command/MigrationDiffCommand.php
@@ -28,6 +28,7 @@ class MigrationDiffCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -54,6 +55,7 @@ class MigrationDiffCommand extends AbstractCommand
      *
      * @throws \Propel\Generator\Exception\RuntimeException
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/MigrationDownCommand.php
+++ b/src/Propel/Generator/Command/MigrationDownCommand.php
@@ -22,6 +22,7 @@ class MigrationDownCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -40,6 +41,7 @@ class MigrationDownCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/MigrationMigrateCommand.php
+++ b/src/Propel/Generator/Command/MigrationMigrateCommand.php
@@ -35,6 +35,7 @@ class MigrationMigrateCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -56,6 +57,7 @@ class MigrationMigrateCommand extends AbstractCommand
      *
      * @throws \Propel\Runtime\Exception\RuntimeException
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/MigrationStatusCommand.php
+++ b/src/Propel/Generator/Command/MigrationStatusCommand.php
@@ -31,6 +31,7 @@ class MigrationStatusCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -48,6 +49,7 @@ class MigrationStatusCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/MigrationUpCommand.php
+++ b/src/Propel/Generator/Command/MigrationUpCommand.php
@@ -24,6 +24,7 @@ class MigrationUpCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -44,6 +45,7 @@ class MigrationUpCommand extends AbstractCommand
      *
      * @throws \Propel\Runtime\Exception\RuntimeException
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -22,6 +22,7 @@ class ModelBuildCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -53,6 +54,7 @@ class ModelBuildCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -21,6 +21,7 @@ class SqlBuildCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -44,6 +45,7 @@ class SqlBuildCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $configOptions = [];

--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -21,6 +21,7 @@ class SqlInsertCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         parent::configure();
@@ -36,6 +37,7 @@ class SqlInsertCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $manager = new SqlManager();

--- a/src/Propel/Generator/Command/TestPrepareCommand.php
+++ b/src/Propel/Generator/Command/TestPrepareCommand.php
@@ -73,6 +73,7 @@ class TestPrepareCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function configure()
     {
         $this
@@ -90,6 +91,7 @@ class TestPrepareCommand extends AbstractCommand
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $result = static::CODE_SUCCESS;

--- a/src/Propel/Generator/Config/GeneratorConfig.php
+++ b/src/Propel/Generator/Config/GeneratorConfig.php
@@ -92,6 +92,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @throws \Propel\Generator\Exception\ClassNotFoundException
      */
+    #[\Override]
     public function getConfiguredPlatform(?ConnectionInterface $con = null, ?string $database = null): ?PlatformInterface
     {
         $platform = $this->get()['generator']['platformClass'];
@@ -140,6 +141,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @throws \Propel\Generator\Exception\ClassNotFoundException
      */
+    #[\Override]
     public function getConfiguredSchemaParser(?ConnectionInterface $con = null, $database = null): ?SchemaParserInterface
     {
         $reverse = $this->get()['migrations']['parserClass'];
@@ -200,6 +202,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
+    #[\Override]
     public function getConfiguredBuilder(Table $table, string $type): AbstractOMBuilder
     {
         $configProperty = 'generator.objectModel.builders.' . $type;
@@ -220,6 +223,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
+    #[\Override]
     public function getConfiguredPluralizer(): PluralizerInterface
     {
         $classname = $this->get()['generator']['objectModel']['pluralizerClass'];
@@ -313,6 +317,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
     /**
      * @return \Propel\Generator\Util\BehaviorLocator
      */
+    #[\Override]
     public function getBehaviorLocator(): BehaviorLocator
     {
         if ($this->behaviorLocator === null) {

--- a/src/Propel/Generator/Config/QuickGeneratorConfig.php
+++ b/src/Propel/Generator/Config/QuickGeneratorConfig.php
@@ -75,6 +75,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
      *
      * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
+    #[\Override]
     public function getConfiguredBuilder(Table $table, string $type): AbstractOMBuilder
     {
         $class = $this->getConfigProperty('generator.objectModel.builders.' . $type);
@@ -95,6 +96,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
+    #[\Override]
     public function getConfiguredPluralizer(): PluralizerInterface
     {
         return new StandardEnglishPluralizer();
@@ -103,6 +105,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getConfiguredPlatform(?ConnectionInterface $con = null, ?string $database = null): ?PlatformInterface
     {
         return null;
@@ -111,6 +114,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getConfiguredSchemaParser(?ConnectionInterface $con = null, ?string $database = null): ?SchemaParserInterface
     {
         return null;
@@ -119,6 +123,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @return \Propel\Generator\Util\BehaviorLocator
      */
+    #[\Override]
     public function getBehaviorLocator(): BehaviorLocator
     {
         if (!$this->behaviorLocator) {

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -447,6 +447,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->setName($this->getAttribute('name'));

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -286,6 +286,7 @@ class Column extends MappingModel
      *
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         try {

--- a/src/Propel/Generator/Model/ConstraintNameGenerator.php
+++ b/src/Propel/Generator/Model/ConstraintNameGenerator.php
@@ -39,6 +39,7 @@ class ConstraintNameGenerator implements NameGeneratorInterface
      *
      * @return string
      */
+    #[\Override]
     public function generateName(array $inputs): string
     {
         /** @var \Propel\Generator\Model\Database $db */

--- a/src/Propel/Generator/Model/CrossRelation.php
+++ b/src/Propel/Generator/Model/CrossRelation.php
@@ -274,6 +274,7 @@ class CrossRelation
     /**
      * @return string
      */
+    #[\Override]
     public function __tostring(): string
     {
         if (!$this->crossForeignKeys) {

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -161,6 +161,7 @@ class Database extends ScopedMappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         parent::setupObject();
@@ -680,6 +681,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
+    #[\Override]
     public function setSchema(?string $schema): void
     {
         $oldSchema = $this->schema;
@@ -805,6 +807,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
+    #[\Override]
     public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         if ($this->parentSchema !== null) {
@@ -823,6 +826,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
+    #[\Override]
     public function getBuildProperty(string $name): string
     {
         $config = $this->getGeneratorConfig();
@@ -915,6 +919,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
+    #[\Override]
     protected function registerBehavior(Behavior $behavior): void
     {
         $behavior->setDatabase($this);

--- a/src/Propel/Generator/Model/Domain.php
+++ b/src/Propel/Generator/Model/Domain.php
@@ -109,6 +109,7 @@ class Domain extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $schemaType = !$this->getAttribute('type')

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -150,6 +150,7 @@ class ForeignKey extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->foreignTableCommonName = $this->sourceTable->getDatabase()->getTablePrefix() . $this->getAttribute('foreignTable');

--- a/src/Propel/Generator/Model/IdMethodParameter.php
+++ b/src/Propel/Generator/Model/IdMethodParameter.php
@@ -36,6 +36,7 @@ class IdMethodParameter extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->name = $this->getAttribute('name');

--- a/src/Propel/Generator/Model/Index.php
+++ b/src/Propel/Generator/Model/Index.php
@@ -338,6 +338,7 @@ class Index extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->setName($this->getAttribute('name'));

--- a/src/Propel/Generator/Model/Inheritance.php
+++ b/src/Propel/Generator/Model/Inheritance.php
@@ -167,6 +167,7 @@ class Inheritance extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->key = $this->getAttribute('key');

--- a/src/Propel/Generator/Model/MappingModel.php
+++ b/src/Propel/Generator/Model/MappingModel.php
@@ -38,6 +38,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return void
      */
+    #[\Override]
     public function loadMapping(array $attributes): void
     {
         $this->attributes = array_change_key_case($attributes, CASE_LOWER);

--- a/src/Propel/Generator/Model/PhpNameGenerator.php
+++ b/src/Propel/Generator/Model/PhpNameGenerator.php
@@ -42,6 +42,7 @@ class PhpNameGenerator implements NameGeneratorInterface
      *
      * @return string The generated name.
      */
+    #[\Override]
     public function generateName(array $inputs): string
     {
         $schemaName = (string)$inputs[0];

--- a/src/Propel/Generator/Model/ScopedMappingModel.php
+++ b/src/Propel/Generator/Model/ScopedMappingModel.php
@@ -68,6 +68,7 @@ abstract class ScopedMappingModel extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->setPackage($this->getAttribute('package', $this->package));

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -197,6 +197,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * @return void
      */
+    #[\Override]
     public function setupObject(): void
     {
         parent::setupObject();
@@ -253,6 +254,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
+    #[\Override]
     public function getBuildProperty(string $name): string
     {
         return $this->database ? $this->database->getBuildProperty($name) : '';
@@ -278,6 +280,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
+    #[\Override]
     protected function registerBehavior(Behavior $behavior): void
     {
         $behavior->setTable($this);
@@ -1137,6 +1140,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
+    #[\Override]
     public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         return $this->database->getGeneratorConfig();
@@ -1899,6 +1903,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\VendorInfo
      */
+    #[\Override]
     public function getVendorInfoForType(string $type): VendorInfo
     {
         $tableVendorInfo = parent::getVendorInfoForType($type);

--- a/src/Propel/Generator/Model/Unique.php
+++ b/src/Propel/Generator/Model/Unique.php
@@ -27,6 +27,7 @@ class Unique extends Index
      *
      * @return bool
      */
+    #[\Override]
     public function isUnique(): bool
     {
         return true;

--- a/src/Propel/Generator/Model/VendorInfo.php
+++ b/src/Propel/Generator/Model/VendorInfo.php
@@ -159,6 +159,7 @@ class VendorInfo extends MappingModel
     /**
      * @return void
      */
+    #[\Override]
     protected function setupObject(): void
     {
         $this->type = $this->getAttribute('type');

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -84,6 +84,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
+    #[\Override]
     public function setConnection(?ConnectionInterface $con = null): void
     {
         $this->con = $con;
@@ -94,6 +95,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface|null
      */
+    #[\Override]
     public function getConnection(): ?ConnectionInterface
     {
         return $this->con;
@@ -102,6 +104,7 @@ class DefaultPlatform implements PlatformInterface
     /**
      * @return bool
      */
+    #[\Override]
     public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
@@ -112,6 +115,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
+    #[\Override]
     public function setIdentifierQuoting(bool $enabled): void
     {
         $this->identifierQuoting = $enabled;
@@ -124,6 +128,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
+    #[\Override]
     public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
     }
@@ -173,6 +178,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
+    #[\Override]
     public function getDatabaseType(): string
     {
         $reflectionClass = new ReflectionClass($this);
@@ -187,6 +193,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return int The max column length
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 64;
@@ -197,6 +204,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
+    #[\Override]
     public function getSchemaDelimiter(): string
     {
         return '.';
@@ -207,6 +215,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string The native IdMethod (PlatformInterface:IDENTITY, PlatformInterface::SEQUENCE).
      */
+    #[\Override]
     public function getNativeIdMethod(): string
     {
         return PlatformInterface::IDENTITY;
@@ -229,6 +238,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return \Propel\Generator\Model\Domain
      */
+    #[\Override]
     public function getDomainForType(string $propelType): Domain
     {
         if (!isset($this->schemaDomainMap[$propelType])) {
@@ -245,6 +255,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
+    #[\Override]
     public function getNullString(bool $notNull): string
     {
         return $notNull ? 'NOT NULL' : '';
@@ -255,6 +266,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
+    #[\Override]
     public function getAutoIncrement(): string
     {
         return 'IDENTITY';
@@ -362,6 +374,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getAddTableDDL(Table $table): string
     {
         $tableDescription = $table->hasDescription() ? $this->getCommentLineDDL($table->getDescription()) : '';
@@ -405,6 +418,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getColumnDDL(Column $col): string
     {
         $domain = $col->getDomain();
@@ -445,6 +459,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getColumnDefaultValueDDL(Column $col): string
     {
         $default = '';
@@ -497,6 +512,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getColumnListDDL(array $columns, string $delimiter = ','): string
     {
         $list = [];
@@ -529,6 +545,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
@@ -1216,6 +1233,7 @@ ALTER TABLE %s ADD
      *
      * @return bool True if the type has a size attribute
      */
+    #[\Override]
     public function hasSize(string $sqlType): bool
     {
         return true;
@@ -1228,6 +1246,7 @@ ALTER TABLE %s ADD
      *
      * @return bool True if the type has a scale attribute
      */
+    #[\Override]
     public function hasScale(string $sqlType): bool
     {
         return true;
@@ -1240,6 +1259,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function quote(string $text): string
     {
         $con = $this->getConnection();
@@ -1273,6 +1293,7 @@ ALTER TABLE %s ADD
      *
      * @return string Quoted identifier.
      */
+    #[\Override]
     public function quoteIdentifier(string $text): string
     {
         return $this->isIdentifierQuotingEnabled() ? $this->doQuoting($text) : $text;
@@ -1281,6 +1302,7 @@ ALTER TABLE %s ADD
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function doQuoting(string $text): string
     {
         return '"' . strtr($text, ['.' => '"."']) . '"';
@@ -1291,6 +1313,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
+    #[\Override]
     public function supportsNativeDeleteTrigger(): bool
     {
         return false;
@@ -1301,6 +1324,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
+    #[\Override]
     public function supportsInsertNullPk(): bool
     {
         return true;
@@ -1309,6 +1333,7 @@ ALTER TABLE %s ADD
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsIndexSize(): bool
     {
         return false;
@@ -1319,6 +1344,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
+    #[\Override]
     public function hasStreamBlobImpl(): bool
     {
         return false;
@@ -1329,6 +1355,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
+    #[\Override]
     public function supportsSchemas(): bool
     {
         return false;
@@ -1339,6 +1366,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
+    #[\Override]
     public function supportsMigrations(): bool
     {
         return true;
@@ -1347,6 +1375,7 @@ ALTER TABLE %s ADD
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsVarcharWithoutSize(): bool
     {
         return false;
@@ -1365,6 +1394,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getBooleanString($value): string
     {
         if ($value === true || $value === 1) {
@@ -1411,6 +1441,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s.u';
@@ -1421,6 +1452,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getTimeFormatter(): string
     {
         return 'H:i:s.u';
@@ -1431,6 +1463,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getDateFormatter(): string
     {
         return 'Y-m-d';
@@ -1441,6 +1474,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getDefaultForeignKeyOnDeleteBehavior(): string
     {
         return ForeignKey::NONE;
@@ -1451,6 +1485,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getDefaultForeignKeyOnUpdateBehavior(): string
     {
         return ForeignKey::NONE;
@@ -1468,6 +1503,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
+    #[\Override]
     public function getColumnBindingPHP(Column $column, string $identifier, string $columnValueAccessor, string $tab = '            '): string
     {
         $script = '';
@@ -1562,6 +1598,7 @@ if (is_resource($columnValueAccessor)) {
      *
      * @return void
      */
+    #[\Override]
     public function normalizeTable(Table $table): void
     {
         if ($table->hasForeignKeys()) {

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -34,6 +34,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return void
      */
+    #[\Override]
     protected function initialize(): void
     {
         parent::initialize();
@@ -64,6 +65,7 @@ class MssqlPlatform extends DefaultPlatform
     /**
      * @return int
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 128;
@@ -74,6 +76,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getNullString(bool $notNull): string
     {
         return $notNull ? 'NOT NULL' : 'NULL';
@@ -82,6 +85,7 @@ class MssqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsNativeDeleteTrigger(): bool
     {
         return true;
@@ -90,6 +94,7 @@ class MssqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsInsertNullPk(): bool
     {
         return false;
@@ -105,6 +110,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getBeginDDL();
@@ -130,6 +136,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getDropTableDDL(Table $table): string
     {
         $ret = '';
@@ -177,6 +184,7 @@ END
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
@@ -197,6 +205,7 @@ END
      *
      * @return string
      */
+    #[\Override]
     public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
@@ -224,6 +233,7 @@ END
      *
      * @return string
      */
+    #[\Override]
     public function getUniqueDDL(Unique $unique): string
     {
         $pattern = 'CONSTRAINT %s UNIQUE NONCLUSTERED (%s) ON [PRIMARY]';
@@ -240,6 +250,7 @@ END
      *
      * @return string
      */
+    #[\Override]
     public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
@@ -269,6 +280,7 @@ END
      *
      * @return bool
      */
+    #[\Override]
     public function supportsSchemas(): bool
     {
         return true;
@@ -279,6 +291,7 @@ END
      *
      * @return bool
      */
+    #[\Override]
     public function hasSize(string $sqlType): bool
     {
         $nosize = ['INT', 'TEXT', 'GEOMETRY', 'VARCHAR(MAX)', 'VARBINARY(MAX)', 'SMALLINT', 'DATETIME', 'TINYINT', 'REAL', 'BIGINT'];
@@ -289,6 +302,7 @@ END
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function doQuoting(string $text): string
     {
         return '[' . strtr($text, ['.' => '].[']) . ']';
@@ -297,6 +311,7 @@ END
     /**
      * @return string
      */
+    #[\Override]
     public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s';

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -56,6 +56,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
+    #[\Override]
     protected function initializeTypeMap(): void
     {
         parent::initializeTypeMap();
@@ -81,6 +82,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
+    #[\Override]
     public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         parent::setGeneratorConfig($generatorConfig);
@@ -170,6 +172,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getAutoIncrement(): string
     {
         return 'AUTO_INCREMENT';
@@ -178,6 +181,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return int
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 64;
@@ -186,6 +190,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsNativeDeleteTrigger(): bool
     {
         return strtolower($this->getDefaultTableEngine()) === 'innodb';
@@ -194,6 +199,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsIndexSize(): bool
     {
         return true;
@@ -223,6 +229,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
         $ret = '';
@@ -241,6 +248,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getBeginDDL(): string
     {
         return "
@@ -253,6 +261,7 @@ SET FOREIGN_KEY_CHECKS = 0;
     /**
      * @return string
      */
+    #[\Override]
     public function getEndDDL(): string
     {
         return "
@@ -268,6 +277,7 @@ SET FOREIGN_KEY_CHECKS = 1;
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
@@ -296,6 +306,7 @@ SET FOREIGN_KEY_CHECKS = 1;
      *
      * @return string
      */
+    #[\Override]
     public function getAddTableDDL(Table $table): string
     {
         $lines = [];
@@ -430,6 +441,7 @@ CREATE TABLE %s
      *
      * @return string
      */
+    #[\Override]
     public function getDropTableDDL(Table $table): string
     {
         return "
@@ -444,6 +456,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getColumnDDL(Column $col): string
     {
         $domain = $col->getDomain();
@@ -595,6 +608,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getDropPrimaryKeyDDL(Table $table): string
     {
         if (!$table->hasPrimaryKey()) {
@@ -613,6 +627,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getAddIndexDDL(Index $index): string
     {
         $pattern = "
@@ -635,6 +650,7 @@ CREATE %sINDEX %s ON %s (%s);
      *
      * @return string
      */
+    #[\Override]
     public function getDropIndexDDL(Index $index): string
     {
         $pattern = "
@@ -655,6 +671,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
+    #[\Override]
     public function getIndexDDL(Index $index): string
     {
         return sprintf(
@@ -688,6 +705,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
+    #[\Override]
     public function getUniqueDDL(Unique $unique): string
     {
         return sprintf(
@@ -702,6 +720,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
+    #[\Override]
     public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         if ($this->supportsForeignKeys($fk->getTable())) {
@@ -718,6 +737,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
+    #[\Override]
     public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($this->supportsForeignKeys($fk->getTable())) {
@@ -732,6 +752,7 @@ DROP INDEX %s ON %s;
      *
      * @return string|null
      */
+    #[\Override]
     public function getDropForeignKeyDDL(ForeignKey $fk): ?string
     {
         if (!$this->supportsForeignKeys($fk->getTable())) {
@@ -756,6 +777,7 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
      *
      * @return string
      */
+    #[\Override]
     public function getCommentBlockDDL(string $comment): string
     {
         $pattern = "
@@ -775,6 +797,7 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
      *
      * @return string
      */
+    #[\Override]
     public function getModifyDatabaseDDL(DatabaseDiff $databaseDiff): string
     {
         $ret = '';
@@ -810,6 +833,7 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
      *
      * @return string
      */
+    #[\Override]
     public function getRenameTableDDL(string $fromTableName, string $toTableName): string
     {
         $pattern = "
@@ -830,6 +854,7 @@ RENAME TABLE %s TO %s;
      *
      * @return string
      */
+    #[\Override]
     public function getRemoveColumnDDL(Column $column): string
     {
         $pattern = "
@@ -851,6 +876,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
+    #[\Override]
     public function getRenameColumnDDL(Column $fromColumn, Column $toColumn): string
     {
         return $this->getChangeColumnDDL($fromColumn, $toColumn);
@@ -863,6 +889,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
+    #[\Override]
     public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         $fromColumn = $columnDiff->getFromColumn();
@@ -906,6 +933,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
+    #[\Override]
     public function getModifyColumnsDDL(array $columnDiffs): string
     {
         $modifyColumnStatements = array_map([$this, 'getModifyColumnDDL'], $columnDiffs);
@@ -920,6 +948,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
+    #[\Override]
     public function getAddColumnDDL(Column $column): string
     {
         $pattern = "
@@ -956,6 +985,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
+    #[\Override]
     public function getAddColumnsDDL(array $columns): string
     {
         $lines = '';
@@ -971,6 +1001,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return bool
      */
+    #[\Override]
     public function supportsSchemas(): bool
     {
         return true;
@@ -981,6 +1012,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return bool
      */
+    #[\Override]
     public function hasSize(string $sqlType): bool
     {
         return !in_array($sqlType, [
@@ -995,6 +1027,7 @@ ALTER TABLE %s ADD %s %s;
     /**
      * @return array<int>
      */
+    #[\Override]
     public function getDefaultTypeSizes(): array
     {
         return [
@@ -1014,6 +1047,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
+    #[\Override]
     public function disconnectedEscapeText(string $text): string
     {
         return addslashes($text);
@@ -1030,6 +1064,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string the quoted identifier
      */
+    #[\Override]
     public function doQuoting(string $text): string
     {
         return '`' . strtr($text, ['.' => '`.`']) . '`';
@@ -1043,6 +1078,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
+    #[\Override]
     public function getColumnBindingPHP(Column $column, string $identifier, string $columnValueAccessor, string $tab = '            '): string
     {
         // FIXME - This is a temporary hack to get around apparent bugs w/ PDO+MYSQL
@@ -1065,6 +1101,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
+    #[\Override]
     public function getDefaultForeignKeyOnDeleteBehavior(): string
     {
         $majorVersion = $this->getMajorServerVersionNumber();
@@ -1077,6 +1114,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
+    #[\Override]
     public function getDefaultForeignKeyOnUpdateBehavior(): string
     {
         $majorVersion = $this->getMajorServerVersionNumber();

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -33,6 +33,7 @@ class OraclePlatform extends DefaultPlatform
      *
      * @return void
      */
+    #[\Override]
     protected function initializeTypeMap(): void
     {
         parent::initializeTypeMap();
@@ -67,6 +68,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return int
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 30;
@@ -75,6 +77,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getNativeIdMethod(): string
     {
         return PlatformInterface::SEQUENCE;
@@ -83,6 +86,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getAutoIncrement(): string
     {
         return '';
@@ -91,6 +95,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsNativeDeleteTrigger(): bool
     {
         return true;
@@ -99,6 +104,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getBeginDDL(): string
     {
         return "
@@ -112,6 +118,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
+    #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getBeginDDL();
@@ -138,6 +145,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
+    #[\Override]
     public function getAddTableDDL(Table $table): string
     {
         $tableDescription = $table->hasDescription() ? $this->getCommentLineDDL($table->getDescription()) : '';
@@ -180,6 +188,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
+    #[\Override]
     public function getAddPrimaryKeyDDL(Table $table): string
     {
         if (is_array($table->getPrimaryKey()) && count($table->getPrimaryKey())) {
@@ -216,6 +225,7 @@ CREATE SEQUENCE %s
      *
      * @return string
      */
+    #[\Override]
     public function getDropTableDDL(Table $table): string
     {
         $ret = "
@@ -235,6 +245,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyName(Table $table): string
     {
         $tableName = $table->getName();
@@ -249,6 +260,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
@@ -270,6 +282,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getUniqueDDL(Unique $unique): string
     {
         return sprintf(
@@ -284,6 +297,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
+    #[\Override]
     public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
@@ -312,6 +326,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return bool
      */
+    #[\Override]
     public function hasStreamBlobImpl(): bool
     {
         return true;
@@ -320,6 +335,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function doQuoting(string $text): string
     {
         return $text;
@@ -328,6 +344,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
     /**
      * @return string
      */
+    #[\Override]
     public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s';
@@ -342,6 +359,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return bool
      */
+    #[\Override]
     public function supportsSchemas(): bool
     {
         return false;
@@ -413,6 +431,7 @@ USING INDEX
      *
      * @return string
      */
+    #[\Override]
     public function getAddIndexDDL(Index $index): string
     {
         // don't create index form primary key
@@ -446,6 +465,7 @@ CREATE %sINDEX %s ON %s (%s)%s;
      *
      * @return string
      */
+    #[\Override]
     public function getColumnBindingPHP(Column $column, string $identifier, string $columnValueAccessor, string $tab = '            '): string
     {
         if ($column->getType() === PropelTypes::CLOB_EMU) {
@@ -478,6 +498,7 @@ CREATE %sINDEX %s ON %s (%s)%s;
      *
      * @return string
      */
+    #[\Override]
     public function getIdentifierPhp(
         string $columnValueMutator,
         string $connectionVariableName = '$con',

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -41,6 +41,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return void
      */
+    #[\Override]
     protected function initializeTypeMap(): void
     {
         parent::initializeTypeMap();
@@ -70,6 +71,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getNativeIdMethod(): string
     {
         return PlatformInterface::SERIAL;
@@ -78,6 +80,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
+    #[\Override]
     public function getAutoIncrement(): string
     {
         return '';
@@ -86,6 +89,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return array<int>
      */
+    #[\Override]
     public function getDefaultTypeSizes(): array
     {
         return [
@@ -101,6 +105,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return int
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 63;
@@ -111,6 +116,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getBooleanString($value): string
     {
         // parent method does the checking for allows string
@@ -123,6 +129,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsNativeDeleteTrigger(): bool
     {
         return true;
@@ -136,6 +143,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getSequenceName(Table $table): string
     {
         $result = null;
@@ -287,6 +295,7 @@ SET search_path TO public;
      *
      * @return string
      */
+    #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getAddSchemasDDL($database);
@@ -317,6 +326,7 @@ SET search_path TO public;
      *
      * @return string
      */
+    #[\Override]
     public function getForeignKeyDDL(ForeignKey $fk): string
     {
         $script = parent::getForeignKeyDDL($fk);
@@ -335,6 +345,7 @@ SET search_path TO public;
     /**
      * @return string
      */
+    #[\Override]
     public function getBeginDDL(): string
     {
         return "
@@ -345,6 +356,7 @@ BEGIN;
     /**
      * @return string
      */
+    #[\Override]
     public function getEndDDL(): string
     {
         return "
@@ -355,6 +367,7 @@ COMMIT;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getAddForeignKeysDDL(Table $table): string
     {
         $ret = '';
@@ -370,6 +383,7 @@ COMMIT;
      *
      * @return string
      */
+    #[\Override]
     public function getAddTableDDL(Table $table): string
     {
         $ret = $this->getUseSchemaDDL($table);
@@ -462,6 +476,7 @@ COMMENT ON COLUMN %s.%s IS %s;
      *
      * @return string
      */
+    #[\Override]
     public function getDropTableDDL(Table $table): string
     {
         $ret = $this->getUseSchemaDDL($table);
@@ -480,6 +495,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyName(Table $table): string
     {
         $tableName = $table->getCommonName();
@@ -492,6 +508,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getColumnDDL(Column $col): string
     {
         $domain = $col->getDomain();
@@ -549,6 +566,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getUniqueDDL(Unique $unique): string
     {
         return sprintf(
@@ -564,6 +582,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getRenameTableDDL(string $fromTableName, string $toTableName): string
     {
         $pos = strpos($toTableName, '.');
@@ -587,6 +606,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return bool
      */
+    #[\Override]
     public function supportsSchemas(): bool
     {
         return true;
@@ -597,6 +617,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return bool
      */
+    #[\Override]
     public function hasSize(string $sqlType): bool
     {
         return !in_array(strtoupper($sqlType), ['BYTEA', 'TEXT', 'DOUBLE PRECISION'], true);
@@ -605,6 +626,7 @@ ALTER TABLE %s RENAME TO %s;
     /**
      * @return bool
      */
+    #[\Override]
     public function hasStreamBlobImpl(): bool
     {
         return true;
@@ -613,6 +635,7 @@ ALTER TABLE %s RENAME TO %s;
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsVarcharWithoutSize(): bool
     {
         return true;
@@ -623,6 +646,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return string
      */
+    #[\Override]
     public function getModifyTableDDL(TableDiff $tableDiff): string
     {
         $ret = parent::getModifyTableDDL($tableDiff);
@@ -647,6 +671,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return string
      */
+    #[\Override]
     public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         $ret = '';
@@ -834,6 +859,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getModifyColumnsDDL(array $columnDiffs): string
     {
         $ret = '';
@@ -855,6 +881,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getAddColumnsDDL(array $columns): string
     {
         $ret = '';
@@ -876,6 +903,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
+    #[\Override]
     public function getDropIndexDDL(Index $index): string
     {
         if ($index instanceof Unique) {
@@ -908,6 +936,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
+    #[\Override]
     public function getIdentifierPhp(
         string $columnValueMutator,
         string $connectionVariableName = '$con',
@@ -937,6 +966,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
+    #[\Override]
     public function getAddIndexDDL(Index $index): string
     {
         if (!$index->isUnique()) {

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -50,6 +50,7 @@ class SqlitePlatform extends DefaultPlatform
     /**
      * @return void
      */
+    #[\Override]
     protected function initialize(): void
     {
         parent::initialize();
@@ -64,6 +65,7 @@ class SqlitePlatform extends DefaultPlatform
      *
      * @return void
      */
+    #[\Override]
     protected function initializeTypeMap(): void
     {
         parent::initializeTypeMap();
@@ -92,6 +94,7 @@ class SqlitePlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getSchemaDelimiter(): string
     {
         return '§';
@@ -100,6 +103,7 @@ class SqlitePlatform extends DefaultPlatform
     /**
      * @return array<int>
      */
+    #[\Override]
     public function getDefaultTypeSizes(): array
     {
         return [
@@ -115,6 +119,7 @@ class SqlitePlatform extends DefaultPlatform
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         parent::setGeneratorConfig($generatorConfig);
@@ -136,6 +141,7 @@ class SqlitePlatform extends DefaultPlatform
      *
      * @return string
      */
+    #[\Override]
     public function getAddColumnsDDL(array $columns): string
     {
         $ret = '';
@@ -157,6 +163,7 @@ ALTER TABLE %s ADD %s;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getModifyTableDDL(TableDiff $tableDiff): string
     {
         $changedNotEditableThroughDirectDDL = $this->tableAlteringWorkaround && (
@@ -277,6 +284,7 @@ DROP TABLE %s;
     /**
      * @return string
      */
+    #[\Override]
     public function getBeginDDL(): string
     {
         return '
@@ -287,6 +295,7 @@ PRAGMA foreign_keys = OFF;
     /**
      * @return string
      */
+    #[\Override]
     public function getEndDDL(): string
     {
         return '
@@ -299,6 +308,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
+    #[\Override]
     public function getAddTablesDDL(Database $database): string
     {
         $ret = '';
@@ -324,6 +334,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return void
      */
+    #[\Override]
     public function normalizeTable(Table $table): void
     {
         if ($table->getPrimaryKey()) {
@@ -378,6 +389,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
+    #[\Override]
     public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey() && !$table->hasAutoIncrementPrimaryKey()) {
@@ -390,6 +402,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getRemoveColumnDDL(Column $column): string
     {
         //not supported
@@ -399,6 +412,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getRenameColumnDDL(Column $fromColumn, Column $toColumn): string
     {
         //not supported
@@ -408,6 +422,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         //not supported
@@ -417,6 +432,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getModifyColumnsDDL($columnDiffs): string
     {
         //not supported
@@ -426,6 +442,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getDropPrimaryKeyDDL(Table $table): string
     {
         //not supported
@@ -435,6 +452,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getAddPrimaryKeyDDL(Table $table): string
     {
         //not supported
@@ -444,6 +462,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         //not supported
@@ -453,6 +472,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getDropForeignKeyDDL(ForeignKey $fk): string
     {
         //not supported
@@ -464,6 +484,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
+    #[\Override]
     public function getAutoIncrement(): string
     {
         return 'PRIMARY KEY AUTOINCREMENT';
@@ -472,6 +493,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @return int
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 1024;
@@ -482,6 +504,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
+    #[\Override]
     public function getColumnDDL(Column $col): string
     {
         if ($col->isAutoIncrement()) {
@@ -509,6 +532,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
+    #[\Override]
     public function getAddTableDDL(Table $table): string
     {
         $table = clone $table;
@@ -563,6 +587,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
+    #[\Override]
     public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || !$this->foreignKeySupport || $fk->isPolymorphic()) {
@@ -595,6 +620,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return bool
      */
+    #[\Override]
     public function hasSize(string $sqlType): bool
     {
         return !in_array($sqlType, [
@@ -609,6 +635,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function doQuoting(string $text): string
     {
         return '[' . strtr($text, ['.' => '].[']) . ']';
@@ -617,6 +644,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsSchemas(): bool
     {
         return true;
@@ -625,6 +653,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @return bool
      */
+    #[\Override]
     public function supportsNativeDeleteTrigger(): bool
     {
         return true;

--- a/src/Propel/Generator/Platform/SqlsrvPlatform.php
+++ b/src/Propel/Generator/Platform/SqlsrvPlatform.php
@@ -20,6 +20,7 @@ class SqlsrvPlatform extends MssqlPlatform
      *
      * @return int
      */
+    #[\Override]
     public function getMaxColumnNameLength(): int
     {
         return 128;

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -90,6 +90,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
+    #[\Override]
     public function setConnection(ConnectionInterface $dbh): void
     {
         $this->dbh = $dbh;
@@ -100,6 +101,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
+    #[\Override]
     public function getConnection(): ConnectionInterface
     {
         return $this->dbh;
@@ -144,6 +146,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return array<string>
      */
+    #[\Override]
     public function getWarnings(): array
     {
         return $this->warnings;
@@ -156,6 +159,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
+    #[\Override]
     public function setGeneratorConfig(GeneratorConfigInterface $config): void
     {
         $this->generatorConfig = $config;
@@ -232,6 +236,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
+    #[\Override]
     public function setPlatform(PlatformInterface $platform): void
     {
         $this->platform = $platform;
@@ -252,6 +257,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
+    #[\Override]
     public function getPlatform(): PlatformInterface
     {
         if ($this->platform === null) {

--- a/src/Propel/Generator/Reverse/MssqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MssqlSchemaParser.php
@@ -78,6 +78,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
+    #[\Override]
     protected function getTypeMapping(): array
     {
         return self::$mssqlTypeMap;
@@ -91,6 +92,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
+    #[\Override]
     public function parse(Database $database, array $additionalTables = []): int
     {
         $dataFetcher = $this->dbh->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME <> 'dtproperties'");

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -90,6 +90,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
+    #[\Override]
     protected function getTypeMapping(): array
     {
         return self::$mysqlTypeMap;
@@ -111,6 +112,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
+    #[\Override]
     public function parse(Database $database, array $additionalTables = []): int
     {
         if ($this->getGeneratorConfig() !== null) {

--- a/src/Propel/Generator/Reverse/OracleSchemaParser.php
+++ b/src/Propel/Generator/Reverse/OracleSchemaParser.php
@@ -67,6 +67,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
+    #[\Override]
     protected function getTypeMapping(): array
     {
         return self::$oracleTypeMap;
@@ -80,6 +81,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
+    #[\Override]
     public function parse(Database $database, array $additionalTables = []): int
     {
         $tables = [];

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -94,6 +94,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
+    #[\Override]
     protected function getTypeMapping(): array
     {
         return self::$pgsqlTypeMap;
@@ -107,6 +108,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
+    #[\Override]
     public function parse(Database $database, array $additionalTables = []): int
     {
         $tableWraps = [];

--- a/src/Propel/Generator/Reverse/SqliteSchemaParser.php
+++ b/src/Propel/Generator/Reverse/SqliteSchemaParser.php
@@ -76,6 +76,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
+    #[\Override]
     protected function getTypeMapping(): array
     {
         return self::$sqliteTypeMap;
@@ -87,6 +88,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
+    #[\Override]
     public function parse(Database $database, array $additionalTables = []): int
     {
         if ($this->getGeneratorConfig()) {

--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -60,6 +60,7 @@ class XmlDumper implements DumperInterface
      *
      * @return string The dumped XML formatted output
      */
+    #[\Override]
     public function dump(Database $database): string
     {
         $this->appendDatabaseNode($database, $this->document);
@@ -75,6 +76,7 @@ class XmlDumper implements DumperInterface
      *
      * @return string
      */
+    #[\Override]
     public function dumpSchema(Schema $schema, bool $doFinalInitialization = true): string
     {
         $rootNode = $this->document->createElement('app-data');

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -296,6 +296,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string|null
      */
+    #[\Override]
     public function getTableForAlias(string $alias): ?string
     {
         if ($this->modelAlias === $alias) {
@@ -324,6 +325,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return \Propel\Runtime\Map\TableMap|null
      */
+    #[\Override]
     public function getTableMap(): ?TableMap
     {
         return $this->tableMap;
@@ -336,6 +338,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string|null
      */
+    #[\Override]
     public function getTableNameInQuery(): ?string
     {
         if ($this->useAliasInSQL && $this->modelAlias) {
@@ -353,6 +356,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return bool
      */
+    #[\Override]
     public function isIdentifiedBy(string $identifier): bool
     {
         return $identifier === $this->getModelAliasOrName()
@@ -371,6 +375,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return \Traversable
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         $res = $this->find(null); // use the default connection

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/LocalColumnExpression.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/LocalColumnExpression.php
@@ -39,6 +39,7 @@ class LocalColumnExpression extends AbstractColumnExpression
     /**
      * @return \Propel\Runtime\Map\ColumnMap|null
      */
+    #[\Override]
     public function getColumnMap(): ?ColumnMap
     {
         return $this->columnMap;
@@ -49,6 +50,7 @@ class LocalColumnExpression extends AbstractColumnExpression
      *
      * @return bool
      */
+    #[\Override]
     public function equals(AbstractColumnExpression $otherColumn): bool
     {
         return $otherColumn instanceof static
@@ -59,6 +61,7 @@ class LocalColumnExpression extends AbstractColumnExpression
     /**
      * @return bool
      */
+    #[\Override]
     public function hasColumnMap(): bool
     {
         return true;
@@ -71,6 +74,7 @@ class LocalColumnExpression extends AbstractColumnExpression
      *
      * @return array{table: ?string, column: string, value: mixed}
      */
+    #[\Override]
     public function buildPdoParam($value): array
     {
         return [

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/RemoteTypedColumnExpression.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/RemoteTypedColumnExpression.php
@@ -47,6 +47,7 @@ class RemoteTypedColumnExpression extends RemoteColumnExpression
     /**
      * @return \Propel\Runtime\Map\ColumnMap|null
      */
+    #[\Override]
     public function getColumnMap(): ?ColumnMap
     {
         return $this->columnMap;
@@ -57,6 +58,7 @@ class RemoteTypedColumnExpression extends RemoteColumnExpression
      *
      * @return bool
      */
+    #[\Override]
     public function equals(AbstractColumnExpression $otherColumn): bool
     {
         return $otherColumn instanceof static
@@ -68,6 +70,7 @@ class RemoteTypedColumnExpression extends RemoteColumnExpression
     /**
      * @return bool
      */
+    #[\Override]
     public function hasColumnMap(): bool
     {
         return (bool)$this->columnMap;
@@ -80,6 +83,7 @@ class RemoteTypedColumnExpression extends RemoteColumnExpression
      *
      * @return array{type: int, value: mixed}| array{column: string, table: string|null, value: mixed}
      */
+    #[\Override]
     public function buildPdoParam($value): array
     {
         if ($this->columnMap) {

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/UpdateColumn/UpdateColumn.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/UpdateColumn/UpdateColumn.php
@@ -59,6 +59,7 @@ class UpdateColumn extends AbstractUpdateColumn
      *
      * @return string
      */
+    #[\Override]
     public function buildExpression(int &$positionIndex): string
     {
         return ':p' . $positionIndex++;

--- a/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/UpdateColumn/UpdateExpression.php
+++ b/src/Propel/Runtime/ActiveQuery/ColumnResolver/ColumnExpression/UpdateColumn/UpdateExpression.php
@@ -117,6 +117,7 @@ class UpdateExpression extends AbstractUpdateColumn
      *
      * @return string
      */
+    #[\Override]
     public function buildExpression(int &$positionIndex): string
     {
         return preg_replace_callback('/\?/', function (array $match) use (&$positionIndex) {
@@ -131,6 +132,7 @@ class UpdateExpression extends AbstractUpdateColumn
      *
      * @return void
      */
+    #[\Override]
     public function collectParam(array &$paramCollector): void
     {
         foreach ($this->value as $index => $value) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -152,6 +152,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return string|null A String with the column name.
      */
+    #[\Override]
     public function getColumnName(): ?string
     {
         return $this->column;
@@ -162,6 +163,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return string
      */
+    #[\Override]
     public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $useQuoteIfEnable
@@ -196,6 +198,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return string|null A String with the table name.
      */
+    #[\Override]
     public function getTableAlias(): ?string
     {
         return $this->table;
@@ -214,6 +217,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
     /**
      * @return string A String with the comparison.
      */
+    #[\Override]
     public function getOperator(): string
     {
         return $this->comparison;
@@ -224,6 +228,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return mixed An Object with the value.
      */
+    #[\Override]
     public function getValue()
     {
         return $this->value;
@@ -232,6 +237,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
     /**
      * @return bool
      */
+    #[\Override]
     public function hasValue(): bool
     {
         return $this->value !== null;
@@ -259,6 +265,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return void
      */
+    #[\Override]
     public function setAdapter(AdapterInterface $adapter): void
     {
         $this->db = $adapter;
@@ -272,6 +279,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return string
      */
+    #[\Override]
     public function buildStatement(array &$paramCollector): string
     {
         $rawExpression = $this->buildCriterionExpression($paramCollector);
@@ -296,6 +304,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return void
      */
+    #[\Override]
     public function collectParameters(array &$paramCollector): void
     {
         $this->buildStatement($paramCollector);
@@ -363,6 +372,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return bool
      */
+    #[\Override]
     public function equals(?object $filter): bool
     {
         if ($this === $filter) {
@@ -400,6 +410,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return array<\Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
      */
+    #[\Override]
     public function getAttachedFilter(): array
     {
         $criterions = parent::getAttachedFilter();
@@ -413,6 +424,7 @@ abstract class AbstractCriterion extends ClauseList implements ColumnFilterInter
      *
      * @return bool
      */
+    #[\Override]
     public function containsCriterion(): bool
     {
         return true;

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractInnerQueryCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractInnerQueryCriterion.php
@@ -113,6 +113,7 @@ abstract class AbstractInnerQueryCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         $leftOperand = $this->leftOperand ? $this->leftOperand . ' ' : '';

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
@@ -59,6 +59,7 @@ abstract class AbstractModelCriterion extends AbstractCriterion
      *
      * @return bool
      */
+    #[\Override]
     public function equals(?object $filter): bool
     {
         return parent::equals($filter)

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
@@ -69,6 +69,7 @@ class BasicCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         $field = ($this->table === null) ? $this->column : $this->table . '.' . $this->column;

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicModelCriterion.php
@@ -26,6 +26,7 @@ class BasicModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if ($this->value !== null) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BinaryCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BinaryCriterion.php
@@ -36,6 +36,7 @@ class BinaryCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if ($this->value !== null) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BinaryModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BinaryModelCriterion.php
@@ -22,6 +22,7 @@ class BinaryModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if ($this->value !== null) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/ColumnToQueryOperatorCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/ColumnToQueryOperatorCriterion.php
@@ -25,6 +25,7 @@ class ColumnToQueryOperatorCriterion extends AbstractInnerQueryCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function initForRelation(ModelCriteria $outerQuery, RelationMap $relation): void
     {
         $outerColumns = $relation->getLeftColumns();
@@ -44,6 +45,7 @@ class ColumnToQueryOperatorCriterion extends AbstractInnerQueryCriterion
      *
      * @return string
      */
+    #[\Override]
     protected function resolveOperator(?string $operatorDeclaration): string
     {
         return $operatorDeclaration ?? trim(Criteria::IN);
@@ -55,6 +57,7 @@ class ColumnToQueryOperatorCriterion extends AbstractInnerQueryCriterion
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria
      */
+    #[\Override]
     protected function processInnerQuery(): Criteria
     {
         return $this->innerQuery;

--- a/src/Propel/Runtime/ActiveQuery/Criterion/CustomCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/CustomCriterion.php
@@ -36,6 +36,7 @@ class CustomCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if ($this->value !== '') {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/ExistsQueryCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/ExistsQueryCriterion.php
@@ -35,6 +35,7 @@ class ExistsQueryCriterion extends AbstractInnerQueryCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function initForRelation(ModelCriteria $outerQuery, RelationMap $relation): void
     {
         $joinCondition = $this->buildJoinCondition($outerQuery, $relation);
@@ -48,6 +49,7 @@ class ExistsQueryCriterion extends AbstractInnerQueryCriterion
      *
      * @return string
      */
+    #[\Override]
     protected function resolveOperator(?string $operatorDeclaration): string
     {
         return ($operatorDeclaration === static::TYPE_NOT_EXISTS) ? static::TYPE_NOT_EXISTS : static::TYPE_EXISTS;
@@ -59,6 +61,7 @@ class ExistsQueryCriterion extends AbstractInnerQueryCriterion
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria
      */
+    #[\Override]
     protected function processInnerQuery(): Criteria
     {
         return $this->innerQuery

--- a/src/Propel/Runtime/ActiveQuery/Criterion/InCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/InCriterion.php
@@ -37,6 +37,7 @@ class InCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         $bindParams = [];

--- a/src/Propel/Runtime/ActiveQuery/Criterion/InModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/InModelCriterion.php
@@ -24,6 +24,7 @@ class InModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         $bindParams = []; // the param names used in query building

--- a/src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
@@ -67,6 +67,7 @@ class LikeCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         $field = ($this->table === null) ? $this->column : $this->table . '.' . $this->column;

--- a/src/Propel/Runtime/ActiveQuery/Criterion/LikeModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/LikeModelCriterion.php
@@ -57,6 +57,7 @@ class LikeModelCriterion extends BasicModelCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         // LIKE is case insensitive in mySQL and SQLite, but not in PostGres

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
@@ -56,6 +56,7 @@ class RawCriterion extends AbstractCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if (substr_count($this->column, '?') !== 1) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
@@ -57,6 +57,7 @@ class RawModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if (substr_count($this->clause, '?') !== 1) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/SeveralModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/SeveralModelCriterion.php
@@ -25,6 +25,7 @@ class SeveralModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
+    #[\Override]
     protected function appendPsForUniqueClauseTo(string &$sb, array &$params): void
     {
         if (!is_array($this->value)) {

--- a/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
+++ b/src/Propel/Runtime/ActiveQuery/DeprecatedCriteriaMethods.php
@@ -73,6 +73,7 @@ class DeprecatedCriteriaMethods extends Criteria
     /**
      * @return \Propel\Runtime\ActiveQuery\Criteria
      */
+    #[\Override]
     public function clear()
     {
         $this->namedCriterions = [];
@@ -87,6 +88,7 @@ class DeprecatedCriteriaMethods extends Criteria
      *
      * @return void
      */
+    #[\Override]
     public function __clone()
     {
         $this->namedCriterions = array_map(fn ($c) => clone $c, $this->namedCriterions);

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractColumnFilter.php
@@ -50,6 +50,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
      *
      * @return string
      */
+    #[\Override]
     public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $this->queryColumn->getColumnExpressionInQuery($useQuoteIfEnable);
@@ -62,6 +63,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
      *
      * @return string
      */
+    #[\Override]
     public function getColumnName(): string
     {
         return $this->queryColumn->getColumnName();
@@ -78,6 +80,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
     /**
      * @return string|null
      */
+    #[\Override]
     public function getTableAlias(): ?string
     {
         return $this->queryColumn->getTableAlias();
@@ -96,6 +99,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
     /**
      * @return string
      */
+    #[\Override]
     public function getOperator(): string
     {
         return $this->operator;
@@ -114,6 +118,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
      *
      * @return void
      */
+    #[\Override]
     protected function resolveUnresolved(): void
     {
         $this->resolveColumn($this->queryColumn);
@@ -149,6 +154,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
      *
      * @return string Positional variable in query for the added parameter
      */
+    #[\Override]
     protected function addParameter(array &$paramCollector, ?array $parameter = null): string
     {
         $parameter = $parameter ?: $this->buildParameter();
@@ -164,6 +170,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
      *
      * @return bool
      */
+    #[\Override]
     public function equals(?object $filter): bool
     {
         return parent::equals($filter)
@@ -177,6 +184,7 @@ abstract class AbstractColumnFilter extends AbstractFilter
      *
      * @return void
      */
+    #[\Override]
     public function __clone()
     {
         parent::__clone();

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilter.php
@@ -43,6 +43,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
     /**
      * @return mixed
      */
+    #[\Override]
     public function getValue()
     {
         return $this->value;
@@ -51,6 +52,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
     /**
      * @return bool
      */
+    #[\Override]
     public function hasValue(): bool
     {
         return $this->value !== null;
@@ -81,6 +83,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
      *
      * @return void
      */
+    #[\Override]
     public function setAdapter(AdapterInterface $adapter): void
     {
         $this->adapter = $adapter;
@@ -112,6 +115,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
      *
      * @return string
      */
+    #[\Override]
     final public function buildStatement(array &$paramCollector): string
     {
         $this->resolveUnresolved();
@@ -164,6 +168,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
      *
      * @return void
      */
+    #[\Override]
     public function collectParameters(array &$paramCollector): void
     {
         $this->buildFilterClause($paramCollector);
@@ -193,6 +198,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
      *
      * @return bool
      */
+    #[\Override]
     public function equals(?object $filter): bool
     {
         if ($this === $filter) {
@@ -216,6 +222,7 @@ abstract class AbstractFilter extends ClauseList implements ColumnFilterInterfac
      *
      * @return array<\Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
      */
+    #[\Override]
     public function getAttachedFilter(): array
     {
         $criterions = parent::getAttachedFilter();

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilterClauseLiteral.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractFilterClauseLiteral.php
@@ -67,6 +67,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
      *
      * @return string
      */
+    #[\Override]
     public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $this->resolvedColumns ? $this->resolvedColumns[0]->getColumnExpressionInQuery($useQuoteIfEnable) : '';
@@ -79,6 +80,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
      *
      * @return string|null
      */
+    #[\Override]
     public function getColumnName(): ?string
     {
         return $this->resolvedColumns ? $this->resolvedColumns[0]->getColumnName() : null;
@@ -99,6 +101,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
      *
      * @return void
      */
+    #[\Override]
     protected function resolveUnresolved(): void
     {
         if ($this->hasUnresolvedColumns()) {
@@ -113,6 +116,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
 
      * @return string
      */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         $numberOfPlaceholders = substr_count($this->clause, '?');
@@ -162,6 +166,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
     /**
      * @return string
      */
+    #[\Override]
     public function getOperator(): string
     {
         return $this->clause;
@@ -170,6 +175,7 @@ abstract class AbstractFilterClauseLiteral extends AbstractFilter
     /**
      * @return string|null
      */
+    #[\Override]
     public function getTableAlias(): ?string
     {
         return $this->resolvedColumns ? $this->resolvedColumns[0]->getTableAlias() : null;

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractInnerQueryFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/AbstractInnerQueryFilter.php
@@ -70,6 +70,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
      *
      * @return string
      */
+    #[\Override]
     public function getLocalColumnName(bool $useQuoteIfEnable): string
     {
         return $this->queryColumn ? $this->queryColumn->getColumnExpressionInQuery($useQuoteIfEnable) : '';
@@ -78,6 +79,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
     /**
      * @return string|null
      */
+    #[\Override]
     public function getColumnName(): ?string
     {
         return $this->queryColumn ? $this->queryColumn->getColumnName() : null;
@@ -86,6 +88,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
     /**
      * @return string
      */
+    #[\Override]
     public function getOperator(): string
     {
         return $this->sqlOperator;
@@ -94,6 +97,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
     /**
      * @return string|null
      */
+    #[\Override]
     public function getTableAlias(): ?string
     {
         return $this->queryColumn ? $this->queryColumn->getTableAlias() : null;
@@ -104,6 +108,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
      *
      * @return void
      */
+    #[\Override]
     protected function resolveUnresolved(): void
     {
         if ($this->queryColumn instanceof UnresolvedColumnExpression) {
@@ -163,6 +168,7 @@ abstract class AbstractInnerQueryFilter extends AbstractFilter
      *
      * @return string
      */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         $leftHandOperator = '';

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/BinaryColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/BinaryColumnFilter.php
@@ -19,6 +19,7 @@ class BinaryColumnFilter extends AbstractColumnFilter
   *
   * @return string
   */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         if ($this->value === null) {

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnFilter.php
@@ -62,6 +62,7 @@ class ColumnFilter extends AbstractColumnFilter
      *
      * @return string
      */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         $field = $this->queryColumn->getColumnExpressionInQuery(true);

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnToQueryFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/ColumnToQueryFilter.php
@@ -26,6 +26,7 @@ class ColumnToQueryFilter extends AbstractInnerQueryFilter
      *
      * @return void
      */
+    #[\Override]
     protected function initForRelation(ModelCriteria $outerQuery, RelationMap $relation): void
     {
         $outerColumns = $relation->getLeftColumns();
@@ -47,6 +48,7 @@ class ColumnToQueryFilter extends AbstractInnerQueryFilter
      *
      * @return string
      */
+    #[\Override]
     protected function resolveOperator(?string $operatorDeclaration): string
     {
         return $operatorDeclaration ?? trim(Criteria::IN);
@@ -58,6 +60,7 @@ class ColumnToQueryFilter extends AbstractInnerQueryFilter
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria
      */
+    #[\Override]
     protected function processInnerQuery(): Criteria
     {
         return $this->innerQuery;

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/ExistsFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/ExistsFilter.php
@@ -32,6 +32,7 @@ class ExistsFilter extends AbstractInnerQueryFilter
      *
      * @return void
      */
+    #[\Override]
     protected function initForRelation(ModelCriteria $outerQuery, RelationMap $relation): void
     {
         $joinCondition = $this->buildJoinCondition($outerQuery, $relation, true);
@@ -45,6 +46,7 @@ class ExistsFilter extends AbstractInnerQueryFilter
      *
      * @return string
      */
+    #[\Override]
     protected function resolveOperator(?string $operatorDeclaration): string
     {
         return ($operatorDeclaration === static::TYPE_NOT_EXISTS) ? static::TYPE_NOT_EXISTS : static::TYPE_EXISTS;
@@ -56,6 +58,7 @@ class ExistsFilter extends AbstractInnerQueryFilter
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria
      */
+    #[\Override]
     protected function processInnerQuery(): Criteria
     {
         return $this->innerQuery

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterClauseLiteralWithColumns.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterClauseLiteralWithColumns.php
@@ -110,6 +110,7 @@ class FilterClauseLiteralWithColumns extends AbstractFilterClauseLiteral
      *
      * @return array
      */
+    #[\Override]
     protected function buildParameterByPosition(int $position, $value): array
     {
         $columnIndex = count($this->resolvedColumns) === 1 ? 0 : $position;

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterClauseLiteralWithPdoTypes.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterClauseLiteralWithPdoTypes.php
@@ -47,6 +47,7 @@ class FilterClauseLiteralWithPdoTypes extends AbstractFilterClauseLiteral
      *
      * @return array{table: null, type: int, value: mixed}
      */
+    #[\Override]
     protected function buildParameterByPosition(int $position, $value): array
     {
         $typeIndex = count($this->pdoTypes) === 1 ? 0 : $position;

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterCollectorCombiner.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterCollectorCombiner.php
@@ -90,6 +90,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return array<\Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
      */
+    #[\Override]
     public function getColumnFilters(): array
     {
         return $this->mergeCombiner(parent::getColumnFilters());
@@ -102,6 +103,7 @@ class FilterCollectorCombiner extends FilterCollector
      *
      * @return void
      */
+    #[\Override]
     public function addFilterWithConjunction(string $andOr, ColumnFilterInterface $filter, bool $preferColumnCondition = true): void
     {
         if ($this->combiner) {
@@ -118,6 +120,7 @@ class FilterCollectorCombiner extends FilterCollector
      *
      * @return \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface|null
      */
+    #[\Override]
     public function findFilterByColumn(string $columnName): ?ColumnFilterInterface
     {
         return parent::findFilterByColumn($columnName) ?? ($this->combiner ? $this->combiner->findFilterByColumn($columnName) : null);
@@ -126,6 +129,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return bool
      */
+    #[\Override]
     public function isEmpty(): bool
     {
         return parent::isEmpty() && (!$this->combiner || $this->combiner->isEmpty());
@@ -134,6 +138,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return void
      */
+    #[\Override]
     public function clear()
     {
         parent::clear();
@@ -146,6 +151,7 @@ class FilterCollectorCombiner extends FilterCollector
      *
      * @return void
      */
+    #[\Override]
     public function merge(FilterCollector $filterCollector, bool $isOr): void
     {
         if ($this->combiner) {
@@ -159,6 +165,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return int
      */
+    #[\Override]
     public function countColumnFilters(): int
     {
         return parent::countColumnFilters() + ($this->combiner ? $this->combiner->countColumnFilters() : 0);
@@ -167,6 +174,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return array<string>
      */
+    #[\Override]
     public function getColumnExpressionsInQuery(): array
     {
         return array_merge(parent::getColumnExpressionsInQuery(), $this->combiner ? $this->combiner->getColumnExpressionsInQuery() : []);
@@ -175,6 +183,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return array<string, \Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>
      */
+    #[\Override]
     public function getColumnFiltersByColumn(): array
     {
         return array_merge(parent::getColumnFiltersByColumn(), $this->combiner ? $this->combiner->getColumnFiltersByColumn() : []);
@@ -187,6 +196,7 @@ class FilterCollectorCombiner extends FilterCollector
      *
      * @return array<string|null, array<\Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface>> array(table => array(table.column1, table.column2))
      */
+    #[\Override]
     public function groupFiltersByTable(?string $defaultTableAlias): array
     {
         if ($this->combiner) {
@@ -201,6 +211,7 @@ class FilterCollectorCombiner extends FilterCollector
      *
      * @return bool
      */
+    #[\Override]
     public function equals(FilterCollector $collector): bool
     {
         if (!parent::equals($collector)) {
@@ -223,6 +234,7 @@ class FilterCollectorCombiner extends FilterCollector
     /**
      * @return void
      */
+    #[\Override]
     public function __clone()
     {
         parent::__clone();

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterCollectorCombiner.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/FilterCollectorCombiner.php
@@ -72,7 +72,8 @@ class FilterCollectorCombiner extends FilterCollector
         if (!$this->combiner || $this->combiner->isEmpty()) {
             return $target;
         }
-        $combinerFilters = $this->combiner->mergeCombiner($this->combiner->columnFilters);
+        /** @var non-empty-array<\Propel\Runtime\ActiveQuery\FilterExpression\ColumnFilterInterface> $combinerFilters */
+        $combinerFilters = $this->combiner->mergeCombiner($this->combiner->columnFilters); // recurse
         $firstFilter = array_shift($combinerFilters);
         foreach ($combinerFilters as $filter) {
             $firstFilter->addAnd($filter);

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/InColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/InColumnFilter.php
@@ -18,6 +18,7 @@ class InColumnFilter extends AbstractColumnFilter
      *
      * @return string
      */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         $values = ($this->value instanceof Traversable) ? iterator_to_array($this->value) : (array)$this->value;

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/JoinCondition.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/JoinCondition.php
@@ -34,6 +34,7 @@ class JoinCondition extends AbstractColumnFilter
      *
      * @return void
      */
+    #[\Override]
     protected function resolveUnresolved(): void
     {
         parent::resolveUnresolved();
@@ -45,6 +46,7 @@ class JoinCondition extends AbstractColumnFilter
      *
      * @return string
      */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         $leftHandExpression = $this->queryColumn->getColumnExpressionInQuery(true);

--- a/src/Propel/Runtime/ActiveQuery/FilterExpression/LikeColumnFilter.php
+++ b/src/Propel/Runtime/ActiveQuery/FilterExpression/LikeColumnFilter.php
@@ -18,6 +18,7 @@ class LikeColumnFilter extends ColumnFilter
      *
      * @return string
      */
+    #[\Override]
     protected function buildFilterClause(array &$paramCollector): string
     {
         $field = $this->getLocalColumnName(true);

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -370,7 +370,7 @@ class ModelCriteria extends BaseModelCriteria
         if ($class == $this->getModelAliasOrName()) {
             // column of the Criteria's model
             $tableMap = $this->getTableMap();
-        } elseif (isset($this->joins[$class])) {
+        } elseif (isset($this->joins[$class]) && $this->joins[$class] instanceof ModelJoin) {
             // column of a relations's model
             $tableMap = $this->joins[$class]->getTableMap();
         } else {
@@ -538,10 +538,10 @@ class ModelCriteria extends BaseModelCriteria
             if ($leftName === $this->getModelAliasOrName() || $leftName === $this->getModelShortName()) {
                 $previousJoin = $this->getPreviousJoin();
                 $tableMap = $this->getTableMap();
-            } elseif (isset($this->joins[$leftName])) {
+            } elseif (isset($this->joins[$leftName]) && $this->joins[$leftName] instanceof ModelJoin) {
                 $previousJoin = $this->joins[$leftName];
                 $tableMap = $previousJoin->getTableMap();
-            } elseif (isset($this->joins[$shortLeftName])) {
+            } elseif (isset($this->joins[$shortLeftName]) && $this->joins[$shortLeftName] instanceof ModelJoin) {
                 $previousJoin = $this->joins[$shortLeftName];
                 $tableMap = $previousJoin->getTableMap();
             } else {

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -465,6 +465,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return bool
      */
+    #[\Override]
     public function hasSelectClause(): bool
     {
         return (bool)$this->select || parent::hasSelectClause();
@@ -654,6 +655,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return $this
      */
+    #[\Override]
     public function addJoinObject(Join $join, ?string $name = null)
     {
         if (!in_array($join, $this->joins)) { // compare equality, NOT identity
@@ -962,6 +964,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return $this The primary criteria object
      */
+    #[\Override]
     public function mergeWith(Criteria $criteria, ?string $operator = null)
     {
         if (
@@ -992,6 +995,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return $this
      */
+    #[\Override]
     public function clear()
     {
         parent::clear();
@@ -1044,6 +1048,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return $this
      */
+    #[\Override]
     public function addSubquery(Criteria $subQuery, ?string $alias = null, bool $addAliasAndSelectColumns = true)
     {
         if (!$subQuery->hasSelectClause()) {
@@ -1728,6 +1733,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
+    #[\Override]
     public function doCount(?ConnectionInterface $con = null): DataFetcherInterface
     {
         $this->configureSelectColumns();
@@ -2007,6 +2013,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return int Number of updated rows
      */
+    #[\Override]
     public function doUpdate($updateValues, ConnectionInterface $con, bool $forceIndividualSaves = false): int
     {
         if ($forceIndividualSaves) {
@@ -2083,6 +2090,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return \Propel\Runtime\ActiveQuery\ColumnResolver\ColumnExpression\AbstractColumnExpression
      */
+    #[\Override]
     public function resolveColumn(string $columnIdentifier, bool $hasAccessToOutputColumns = false, bool $failSilently = true): AbstractColumnExpression
     {
         return $this->columnResolver->resolveColumn($columnIdentifier, $hasAccessToOutputColumns, $failSilently);
@@ -2095,6 +2103,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface A dataFetcher using the connection, ready to be fetched
      */
+    #[\Override]
     public function doSelect(?ConnectionInterface $con = null): DataFetcherInterface
     {
         $this->configureSelectColumns();
@@ -2112,6 +2121,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return string
      */
+    #[\Override]
     public function createSelectSql(array &$params): string
     {
         $this->configureSelectColumns();
@@ -2199,6 +2209,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return mixed
      */
+    #[\Override]
     public function __call(string $name, array $arguments)
     {
         // Maybe it's a magic call to one of the methods supporting it, e.g. 'findByTitle'
@@ -2270,6 +2281,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return void
      */
+    #[\Override]
     public function __clone()
     {
         parent::__clone();
@@ -2290,6 +2302,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @return $this
      */
+    #[\Override]
     public function addSelectColumn($name)
     {
         $this->isSelfSelected = true;
@@ -2300,6 +2313,7 @@ class ModelCriteria extends BaseModelCriteria
     /**
      * @return bool
      */
+    #[\Override]
     protected function isEmpty(): bool
     {
         return parent::isEmpty() && !($this->formatter || $this->modelAlias || $this->with || $this->select);

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -250,6 +250,7 @@ class ModelJoin extends Join
     /**
      * @return bool
      */
+    #[\Override]
     public function isIdentifierQuotingEnabled(): bool
     {
         return $this->getTableMap()->isIdentifierQuotingEnabled();
@@ -285,6 +286,7 @@ class ModelJoin extends Join
      *
      * @return bool
      */
+    #[\Override]
     public function equals(Join $join): bool
     {
         /** @phpstan-var \Propel\Runtime\ActiveQuery\ModelJoin $join */
@@ -311,6 +313,7 @@ class ModelJoin extends Join
      *
      * @return bool
      */
+    #[\Override]
     public function isIdentifiedBy(string $identifier): bool
     {
         return parent::isIdentifiedBy($identifier)

--- a/src/Propel/Runtime/ActiveRecord/NestedSetRecursiveIterator.php
+++ b/src/Propel/Runtime/ActiveRecord/NestedSetRecursiveIterator.php
@@ -61,8 +61,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
      *
      * @return mixed
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function current()
     {
         return $this->curNode;
@@ -73,8 +72,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
      *
      * @return string
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function key(): string
     {
         $method = method_exists($this->curNode, 'getPath') ? 'getPath' : 'getAncestors';

--- a/src/Propel/Runtime/ActiveRecord/NestedSetRecursiveIterator.php
+++ b/src/Propel/Runtime/ActiveRecord/NestedSetRecursiveIterator.php
@@ -41,6 +41,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
     /**
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         $this->curNode = $this->topNode;
@@ -49,6 +50,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
     /**
      * @return bool
      */
+    #[\Override]
     public function valid(): bool
     {
         return $this->curNode !== null;
@@ -59,6 +61,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
      *
      * @return mixed
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function current()
     {
@@ -70,6 +73,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
      *
      * @return string
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function key(): string
     {
@@ -85,6 +89,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
     /**
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         $nextNode = null;
@@ -108,6 +113,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
     /**
      * @return bool
      */
+    #[\Override]
     public function hasChildren(): bool
     {
         return $this->curNode->hasChildren();
@@ -116,6 +122,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
     /**
      * @return \Propel\Runtime\ActiveRecord\NestedSetRecursiveIterator|\RecursiveIterator<int|string, mixed>|null
      */
+    #[\Override]
     public function getChildren(): ?RecursiveIterator
     {
         $method = method_exists($this->curNode, 'retrieveFirstChild') ? 'retrieveFirstChild' : 'getFirstChild';

--- a/src/Propel/Runtime/Adapter/MSSQL/MssqlPropelPDO.php
+++ b/src/Propel/Runtime/Adapter/MSSQL/MssqlPropelPDO.php
@@ -25,6 +25,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
+    #[\Override]
     public function beginTransaction(): bool
     {
         $return = true;
@@ -51,6 +52,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
+    #[\Override]
     public function commit(): bool
     {
         $return = true;
@@ -80,6 +82,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
+    #[\Override]
     public function rollBack(): bool
     {
         $return = true;
@@ -108,6 +111,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
+    #[\Override]
     public function forceRollBack(): bool
     {
         $return = true;
@@ -134,6 +138,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return int
      */
+    #[\Override]
     public function lastInsertId(?string $name = null): int
     {
         $result = $this->query('SELECT SCOPE_IDENTITY()');

--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -34,6 +34,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function setCharset(ConnectionInterface $con, string $charset): void
     {
     }
@@ -46,6 +47,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function concatString(string $s1, string $s2): string
     {
         return '(' . $s1 . ' + ' . $s2 . ')';
@@ -60,6 +62,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function subString(string $s, int $pos, int $len): string
     {
         return 'SUBSTRING(' . $s . ', ' . $pos . ', ' . $len . ')';
@@ -72,6 +75,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function strLength(string $s): string
     {
         return 'LEN(' . $s . ')';
@@ -80,6 +84,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function compareRegex($left, $right): string
     {
         return sprintf('dbo.RegexMatch(%s, %s', $left, $right);
@@ -92,6 +97,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function quoteIdentifier(string $text): string
     {
         return '[' . $text . ']';
@@ -104,6 +110,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function quoteIdentifierTable(string $table): string
     {
         // e.g. 'database.table alias' should be escaped as '[database].[table] [alias]'
@@ -117,6 +124,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function random(?string $seed = null): string
     {
         return 'RAND(' . ((int)$seed) . ')';
@@ -142,6 +150,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLimit(string &$sql, int $offset, int $limit, ?Criteria $criteria = null): void
     {
         // split the select and from clauses out of the original query
@@ -292,6 +301,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function cleanupSQL(string &$sql, array &$params, Criteria $values, DatabaseMap $dbMap): void
     {
         $i = 1;
@@ -340,6 +350,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLock(string &$sql, Lock $lock): void
     {
     }
@@ -349,6 +360,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s:000';
@@ -359,6 +371,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function getTimeFormatter(): string
     {
         return 'H:i:s:000';

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -34,6 +34,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function concatString(string $s1, string $s2): string
     {
         return "CONCAT($s1, $s2)";
@@ -48,6 +49,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function subString(string $s, int $pos, int $len): string
     {
         return "SUBSTRING($s, $pos, $len)";
@@ -60,6 +62,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function strLength(string $s): string
     {
         return "CHAR_LENGTH($s)";
@@ -98,6 +101,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function quoteIdentifier(string $text): string
     {
         return '`' . $text . '`';
@@ -110,6 +114,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function quoteIdentifierTable(string $table): string
     {
         // e.g. 'database.table alias' should be escaped as '`database`.`table` `alias`'
@@ -126,6 +131,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLimit(string &$sql, int $offset, int $limit, ?Criteria $criteria = null): void
     {
         if ($limit >= 0) {
@@ -142,6 +148,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function random(?string $seed = null): string
     {
         return 'rand(' . ((int)$seed) . ')';
@@ -158,6 +165,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function bindValue(StatementInterface $stmt, string $parameter, $value, ColumnMap $cMap, ?int $position = null): bool
     {
         $pdoType = $cMap->getPdoType();
@@ -191,6 +199,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return array the modified parameters
      */
+    #[\Override]
     protected function prepareParams(array $params): array
     {
         if (isset($params['settings']['charset'])) {
@@ -211,6 +220,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLock(string &$sql, Lock $lock): void
     {
         $type = $lock->getType();

--- a/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
@@ -43,6 +43,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function initConnection(ConnectionInterface $con, array $settings): void
     {
         $con->exec("ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD'");
@@ -64,6 +65,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function concatString(string $s1, string $s2): string
     {
         return "CONCAT($s1, $s2)";
@@ -72,6 +74,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function compareRegex($left, $right): string
     {
         return sprintf('REGEXP_LIKE(%s, %s)', $left, $right);
@@ -86,6 +89,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function subString(string $s, int $pos, int $len): string
     {
         return "SUBSTR($s, $pos, $len)";
@@ -98,6 +102,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function strLength(string $s): string
     {
         return "LENGTH($s)";
@@ -113,6 +118,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLimit(string &$sql, int $offset, int $limit, ?Criteria $criteria = null): void
     {
         $params = [];
@@ -138,6 +144,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @return int
      */
+    #[\Override]
     protected function getIdMethod(): int
     {
         return AdapterInterface::ID_METHOD_SEQUENCE;
@@ -152,6 +159,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return int
      */
+    #[\Override]
     public function getId(ConnectionInterface $con, ?string $name = null): int
     {
         if ($name === null) {
@@ -171,6 +179,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function random(?string $seed = null): string
     {
         return 'dbms_random.value';
@@ -186,6 +195,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria The input, with Select columns replaced by aliases
      */
+    #[\Override]
     public function turnSelectColumnsToAliases(Criteria $criteria): Criteria
     {
         $selectColumns = $criteria->getSelectColumns();
@@ -227,6 +237,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function bindValue(StatementInterface $stmt, string $parameter, $value, ColumnMap $cMap, ?int $position = null): bool
     {
         if ($cMap->getType() === PropelTypes::CLOB_EMU) {
@@ -251,6 +262,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return array
      */
+    #[\Override]
     protected function prepareParams(array $params): array
     {
         if (isset($params['dsn'])) {
@@ -268,6 +280,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLock(string &$sql, Lock $lock): void
     {
         $type = $lock->getType();

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -40,6 +40,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function concatString(string $s1, string $s2): string
     {
         return "($s1 || $s2)";
@@ -48,6 +49,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function compareRegex($left, $right): string
     {
         return sprintf('%s ~* %s', $left, $right);
@@ -62,6 +64,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function subString(string $s, int $pos, int $len): string
     {
         return "substring($s from $pos" . ($len > -1 ? "for $len" : '') . ')';
@@ -74,6 +77,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function strLength(string $s): string
     {
         return "char_length($s)";
@@ -84,6 +88,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return int
      */
+    #[\Override]
     protected function getIdMethod(): int
     {
         return AdapterInterface::ID_METHOD_SEQUENCE;
@@ -100,6 +105,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return int
      */
+    #[\Override]
     public function getId(ConnectionInterface $con, ?string $name = null): int
     {
         if ($name === null) {
@@ -120,6 +126,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s.u O';
@@ -130,6 +137,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function getTimeFormatter(): string
     {
         return 'H:i:s.u O';
@@ -145,6 +153,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLimit(string &$sql, int $offset, int $limit, ?Criteria $criteria = null): void
     {
         if ($limit >= 0) {
@@ -160,6 +169,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function getGroupBy(Criteria $criteria): string
     {
         $groupBy = $criteria->getGroupByColumns();
@@ -197,6 +207,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function random(?string $seed = null): string
     {
         return 'random()';
@@ -209,6 +220,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function quoteIdentifierTable(string $table): string
     {
         // e.g. 'database.table alias' should be escaped as '"database"."table" "alias"'
@@ -271,6 +283,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLock(string &$sql, Lock $lock): void
     {
         $type = $lock->getType();

--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -29,6 +29,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function setCharset(ConnectionInterface $con, string $charset): void
     {
     }
@@ -39,6 +40,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function initConnection(ConnectionInterface $con, array $settings): void
     {
         $con->query('PRAGMA foreign_keys = ON');
@@ -60,6 +62,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function concatString(string $s1, string $s2): string
     {
         return "($s1 || $s2)";
@@ -74,6 +77,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function subString(string $s, int $pos, int $len): string
     {
         return "substr($s, $pos, $len)";
@@ -86,6 +90,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function strLength(string $s): string
     {
         return "length($s)";
@@ -98,6 +103,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function quoteIdentifier(string $text): string
     {
         return "[$text]";
@@ -113,6 +119,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLimit(string &$sql, int $offset, int $limit, ?Criteria $criteria = null): void
     {
         if ($limit >= 0) {
@@ -127,6 +134,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
+    #[\Override]
     public function random(?string $seed = null): string
     {
         return 'random()';
@@ -140,6 +148,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function applyLock(string &$sql, Lock $lock): void
     {
     }

--- a/src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php
@@ -32,6 +32,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function initConnection(ConnectionInterface $con, array $settings): void
     {
         $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -50,6 +51,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function setCharset(ConnectionInterface $con, string $charset): void
     {
         switch (strtolower($charset)) {
@@ -76,6 +78,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return void
      */
+    #[\Override]
     public function cleanupSQL(string &$sql, array &$params, Criteria $values, DatabaseMap $dbMap): void
     {
         $i = 1;
@@ -107,6 +110,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function bindValue(StatementInterface $stmt, string $parameter, $value, ColumnMap $cMap, ?int $position = null): bool
     {
         if ($cMap->isTemporal()) {

--- a/src/Propel/Runtime/Collection/ArrayCollection.php
+++ b/src/Propel/Runtime/Collection/ArrayCollection.php
@@ -169,6 +169,7 @@ class ArrayCollection extends Collection
      *
      * @return array<array<string, mixed>>
      */
+    #[\Override]
     public function getArrayCopy(?string $keyColumn = null, bool $usePrefix = false): array
     {
         if ($keyColumn === null && $usePrefix === false) {

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -131,8 +131,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return RowFormat|null
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function &offsetGet($offset)
     {
         if (isset($this->data[$offset])) {
@@ -449,8 +448,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return string
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function serialize(): string
     {
         $repr = [
@@ -467,8 +465,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function unserialize($data): void
     {
         $repr = unserialize($data);

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -118,6 +118,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return bool
      */
+    #[\Override]
     public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
@@ -130,6 +131,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return RowFormat|null
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function &offsetGet($offset)
     {
@@ -148,6 +150,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
+    #[\Override]
     public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
@@ -162,6 +165,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
+    #[\Override]
     public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
@@ -210,6 +214,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return \Propel\Runtime\Collection\CollectionIterator|\Propel\Runtime\Collection\IteratorInterface
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return new CollectionIterator($this);
@@ -220,6 +225,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->data);
@@ -443,6 +449,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return string
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function serialize(): string
     {
@@ -460,6 +467,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function unserialize($data): void
     {

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -254,8 +254,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function asort(int $flags = SORT_REGULAR): bool
     {
         parent::asort();
@@ -269,8 +268,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function ksort(int $flags = SORT_REGULAR): bool
     {
         parent::ksort();
@@ -284,8 +282,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function uasort($cmp_function): bool
     {
         parent::uasort($cmp_function);
@@ -299,8 +296,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function uksort($cmp_function): bool
     {
         parent::uksort($cmp_function);
@@ -312,8 +308,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @return true
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function natsort(): bool
     {
         parent::natsort();
@@ -325,8 +320,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @return true
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function natcasesort(): bool
     {
         parent::natcasesort();

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -215,6 +215,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return void
      */
+    #[\Override]
     public function offsetSet($offset, $value): void
     {
         $this->collection->offsetSet($offset, $value);
@@ -227,6 +228,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return void
      */
+    #[\Override]
     public function offsetUnset($offset): void
     {
         $this->collection->offsetUnset($offset);
@@ -239,6 +241,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return void
      */
+    #[\Override]
     public function append($value): void
     {
         $this->collection->append($value);
@@ -251,6 +254,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function asort(int $flags = SORT_REGULAR): bool
     {
@@ -265,6 +269,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function ksort(int $flags = SORT_REGULAR): bool
     {
@@ -279,6 +284,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function uasort($cmp_function): bool
     {
@@ -293,6 +299,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
      *
      * @return true
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function uksort($cmp_function): bool
     {
@@ -305,6 +312,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @return true
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function natsort(): bool
     {
@@ -317,6 +325,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @return true
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function natcasesort(): bool
     {

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -52,6 +52,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function exchangeArray(array $input): void
     {
         $this->data = $input;
@@ -63,6 +64,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function setData(array $data): void
     {
         parent::setData($data);
@@ -240,6 +242,7 @@ class ObjectCollection extends Collection
      *
      * @return array<int|string, mixed>
      */
+    #[\Override]
     public function getArrayCopy(?string $keyColumn = null, bool $usePrefix = false): array
     {
         if ($keyColumn === null && $usePrefix === false) {
@@ -417,6 +420,7 @@ class ObjectCollection extends Collection
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function search($element)
     {
         $splHash = spl_object_hash($element);
@@ -451,6 +455,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function offsetUnset($offset): void
     {
         if (isset($this->data[$offset])) {
@@ -480,6 +485,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function append($value): void
     {
         if (!is_object($value)) {
@@ -503,6 +509,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function offsetSet($offset, $value): void
     {
         if (!is_object($value)) {
@@ -535,6 +542,7 @@ class ObjectCollection extends Collection
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function contains($element): bool
     {
         if (!is_object($element)) {

--- a/src/Propel/Runtime/Collection/ObjectCombinationCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCombinationCollection.php
@@ -27,6 +27,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return array The list of the primary keys of the collection
      */
+    #[\Override]
     public function getPrimaryKeys(bool $usePrefix = true): array
     {
         $ret = [];
@@ -48,6 +49,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return void
      */
+    #[\Override]
     public function push($value): void
     {
         if (func_num_args() > 1) { // previous version used type-breaking variadic args
@@ -79,6 +81,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return string|int|false
      */
+    #[\Override]
     public function search($element)
     {
         if (func_num_args() > 1) { // previous version used type-breaking variadic args
@@ -114,6 +117,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return void
      */
+    #[\Override]
     public function removeObject($element): void
     {
         if (func_num_args() > 1) { // previous version used type-breaking variadic args
@@ -131,6 +135,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return bool
      */
+    #[\Override]
     public function contains($element): bool
     {
         if (func_num_args() > 1) { // previous version used type-breaking variadic args

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -114,6 +114,7 @@ class OnDemandCollection extends Collection
     /**
      * @return \Propel\Runtime\Collection\OnDemandIterator<RowFormat, \Propel\Runtime\Collection\OnDemandCollection<RowFormat>>
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return $this->lastIterator;
@@ -128,6 +129,7 @@ class OnDemandCollection extends Collection
      *
      * @return bool
      */
+    #[\Override]
     public function offsetExists($offset): bool
     {
         throw new PropelException('The On Demand Collection does not allow access by offset');
@@ -142,6 +144,7 @@ class OnDemandCollection extends Collection
      *
      * @return mixed
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function &offsetGet($offset)
     {
@@ -156,6 +159,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function offsetSet($offset, $value): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
@@ -168,6 +172,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function offsetUnset($offset): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
@@ -180,6 +185,7 @@ class OnDemandCollection extends Collection
      *
      * @return string
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function serialize(): string
     {
@@ -193,6 +199,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function unserialize($data): void
     {
@@ -206,6 +213,7 @@ class OnDemandCollection extends Collection
      *
      * @return int Number of results
      */
+    #[\Override]
     public function count(): int
     {
         return $this->getIterator()->count();
@@ -220,6 +228,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function append($value): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
@@ -232,6 +241,7 @@ class OnDemandCollection extends Collection
      *
      * @return int
      */
+    #[\Override]
     public function prepend($value): int
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
@@ -244,6 +254,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
+    #[\Override]
     public function exchangeArray(array $input): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
@@ -254,6 +265,7 @@ class OnDemandCollection extends Collection
      *
      * @return array
      */
+    #[\Override]
     public function getArrayCopy(): array
     {
         throw new PropelException('The On Demand Collection does not allow access by offset');
@@ -264,6 +276,7 @@ class OnDemandCollection extends Collection
      *
      * @throws \Propel\Runtime\Exception\PropelException
      */
+    #[\Override]
     public function exportTo($parser, bool $usePrefix = true, bool $includeLazyLoadColumns = true, string $keyType = TableMap::TYPE_PHPNAME): string
     {
         throw new PropelException('A OnDemandCollection cannot be exported.');

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -144,8 +144,7 @@ class OnDemandCollection extends Collection
      *
      * @return mixed
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function &offsetGet($offset)
     {
         throw new PropelException('The On Demand Collection does not allow access by offset');
@@ -185,8 +184,7 @@ class OnDemandCollection extends Collection
      *
      * @return string
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function serialize(): string
     {
         throw new PropelException('The On Demand Collection cannot be serialized');
@@ -199,8 +197,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function unserialize($data): void
     {
         throw new PropelException('The On Demand Collection cannot be serialized');

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -101,8 +101,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return RowFormat
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function current(): ActiveRecordInterface
     {
         if (!is_array($this->currentRow)) {
@@ -119,8 +118,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return int
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function key(): int
     {
         return $this->currentKey;

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -83,6 +83,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return int Number of results
      */
+    #[\Override]
     public function count(): int
     {
         return $this->dataFetcher->count();
@@ -100,6 +101,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return RowFormat
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function current(): ActiveRecordInterface
     {
@@ -117,6 +119,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return int
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function key(): int
     {
@@ -129,6 +132,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         $this->currentRow = $this->dataFetcher->fetch();
@@ -147,6 +151,7 @@ class OnDemandIterator implements IteratorInterface
      *
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         // check that the hydration can begin
@@ -167,6 +172,7 @@ class OnDemandIterator implements IteratorInterface
     /**
      * @return bool
      */
+    #[\Override]
     public function valid(): bool
     {
         return $this->isValid;

--- a/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
@@ -58,6 +58,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return void
      */
+    #[\Override]
     public function setName(string $name): void
     {
         $this->name = $name;
@@ -66,6 +67,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
     /**
      * @return string The datasource name associated to this connection
      */
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
@@ -151,6 +153,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
+    #[\Override]
     public function getWriteConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         if ($this->writeConnection === null) {
@@ -171,6 +174,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
+    #[\Override]
     public function getReadConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         if ($this->writeConnection && $this->writeConnection->inTransaction()) {
@@ -198,6 +202,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
     /**
      * @return void
      */
+    #[\Override]
     public function closeConnections(): void
     {
         $this->writeConnection = null;

--- a/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
@@ -44,6 +44,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return void
      */
+    #[\Override]
     public function setName(string $name): void
     {
         $this->name = $name;
@@ -52,6 +53,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     /**
      * @return string The datasource name associated to this connection
      */
+    #[\Override]
     public function getName(): string
     {
         return $this->name;
@@ -94,6 +96,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
+    #[\Override]
     public function getWriteConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         if ($this->connection === null) {
@@ -113,6 +116,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
+    #[\Override]
     public function getReadConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         return $this->getWriteConnection($adapter);
@@ -121,6 +125,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     /**
      * @return void
      */
+    #[\Override]
     public function closeConnections(): void
     {
         $this->connection = null;

--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -149,6 +149,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
+    #[\Override]
     public function setName(string $name): void
     {
         $this->name = $name;
@@ -157,6 +158,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @return string|null The datasource name associated to this connection
      */
+    #[\Override]
     public function getName(): ?string
     {
         return $this->name;
@@ -219,6 +221,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
+    #[\Override]
     public function beginTransaction(): bool
     {
         $return = true;
@@ -242,6 +245,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
+    #[\Override]
     public function commit(): bool
     {
         $return = true;
@@ -271,6 +275,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool Whether operation was successful.
      */
+    #[\Override]
     public function rollBack(): bool
     {
         $return = true;
@@ -324,6 +329,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool TRUE if a transaction is currently active, and FALSE if not.
      */
+    #[\Override]
     public function inTransaction(): bool
     {
         return $this->connection->inTransaction();
@@ -338,6 +344,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      * @return mixed A successful call returns the value of the requested attribute.
      *               An unsuccessful call returns null.
      */
+    #[\Override]
     public function getAttribute(int $attribute)
     {
         switch ($attribute) {
@@ -358,6 +365,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
+    #[\Override]
     public function setAttribute($attribute, $value): bool
     {
         if (is_string($attribute)) {
@@ -401,6 +409,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return \Propel\Runtime\Connection\StatementInterface|false
      */
+    #[\Override]
     public function prepare(string $statement, array $driverOptions = [])
     {
         if ($this->isCachePreparedStatements && isset($this->cachedPreparedStatements[$statement])) {
@@ -423,6 +432,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function exec($statement): int
     {
         if ($this->isInDebugMode()) {
@@ -449,6 +459,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
+    #[\Override]
     public function query(string $statement, ...$args): DataFetcherInterface
     {
         $statementWrapper = $this->createStatementWrapper($statement);
@@ -511,6 +522,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *                SQL statement. Returns FALSE if the driver does not support
      *                quoting in this way.
      */
+    #[\Override]
     public function quote(string $string, int $parameterType = 2): string
     {
         return $this->connection->quote($string, $parameterType);
@@ -519,6 +531,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getSingleDataFetcher($data): DataFetcherInterface
     {
         return $this->connection->getSingleDataFetcher($data);
@@ -527,6 +540,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getDataFetcher($data): DataFetcherInterface
     {
         return $this->connection->getDataFetcher($data);
@@ -561,6 +575,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *                a string representing the last value retrieved from the specified
      *                sequence object.
      */
+    #[\Override]
     public function lastInsertId(?string $name = null)
     {
         return $this->connection->lastInsertId($name);
@@ -674,6 +689,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
+    #[\Override]
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -48,6 +48,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return void
      */
+    #[\Override]
     public function setName(string $name): void
     {
         $this->name = $name;
@@ -56,6 +57,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return string|null The datasource name associated to this connection
      */
+    #[\Override]
     public function getName(): ?string
     {
         return $this->name;
@@ -96,6 +98,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return bool
      */
+    #[\Override]
     public function setAttribute($attribute, $value): bool
     {
         if (is_string($attribute) && strpos($attribute, '::') === false) {
@@ -112,6 +115,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getDataFetcher($data): DataFetcherInterface
     {
         return new PDODataFetcher($data);
@@ -120,6 +124,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getSingleDataFetcher($data): DataFetcherInterface
     {
         return $this->getDataFetcher($data);
@@ -130,6 +135,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return \PDOStatement|false
      */
+    #[\Override]
     public function query(string $statement)
     {
         return $this->pdo->query($statement);
@@ -140,6 +146,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return int
      */
+    #[\Override]
     public function exec($statement): int
     {
         return (int)$this->pdo->exec($statement);
@@ -148,6 +155,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function inTransaction(): bool
     {
         return $this->pdo->inTransaction();
@@ -156,6 +164,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getAttribute(int $attribute)
     {
         return $this->pdo->getAttribute($attribute);
@@ -166,6 +175,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return string|false
      */
+    #[\Override]
     public function lastInsertId(?string $name = null)
     {
         return $this->pdo->lastInsertId();
@@ -179,6 +189,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return \PDOStatement|false
      */
+    #[\Override]
     public function prepare(string $statement, array $driverOptions = [])
     {
         return $this->pdo->prepare($statement, $driverOptions);
@@ -192,6 +203,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return string
      */
+    #[\Override]
     public function quote(string $string, int $parameterType = PDO::PARAM_STR): string
     {
         return $this->pdo->quote($string, $parameterType);
@@ -200,6 +212,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return bool
      */
+    #[\Override]
     public function beginTransaction(): bool
     {
         return $this->pdo->beginTransaction();
@@ -208,6 +221,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return bool
      */
+    #[\Override]
     public function commit(): bool
     {
         return $this->pdo->commit();
@@ -216,6 +230,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return bool
      */
+    #[\Override]
     public function rollBack(): bool
     {
         return $this->pdo->rollBack();

--- a/src/Propel/Runtime/Connection/ProfilerConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ProfilerConnectionWrapper.php
@@ -66,6 +66,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
      *
      * @return bool
      */
+    #[\Override]
     public function setAttribute($attribute, $value): bool
     {
         switch ($attribute) {
@@ -83,6 +84,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function prepare(string $statement, array $driverOptions = [])
     {
         $this->getProfiler()->start();
@@ -93,6 +95,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function exec($statement): int
     {
         $this->getProfiler()->start();
@@ -103,6 +106,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function query($statement = '', ...$args): DataFetcherInterface
     {
         $this->getProfiler()->start();
@@ -113,6 +117,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function createStatementWrapper($sql): StatementWrapper
     {
         return new ProfilerStatementWrapper($sql, $this);
@@ -121,6 +126,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function log($msg): void
     {
         if ($this->isSlowOnly && !$this->getProfiler()->isSlow()) {

--- a/src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
+++ b/src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
@@ -29,6 +29,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      *
      * @return bool
      */
+    #[\Override]
     public function bindParam($parameter, &$variable, int $dataType = PDO::PARAM_STR, ?int $length = null, $driverOptions = null): bool
     {
         $this->connection->getProfiler()->start();
@@ -46,6 +47,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      *
      * @return bool
      */
+    #[\Override]
     public function bindValue($parameter, $value, int $dataType = PDO::PARAM_STR): bool
     {
         $this->connection->getProfiler()->start();
@@ -61,6 +63,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      *
      * @return bool
      */
+    #[\Override]
     public function execute(?array $inputParameters = null): bool
     {
         $this->connection->getProfiler()->start();

--- a/src/Propel/Runtime/Connection/StatementWrapper.php
+++ b/src/Propel/Runtime/Connection/StatementWrapper.php
@@ -118,6 +118,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool
      */
+    #[\Override]
     public function bindParam($parameter, &$variable, int $dataType = PDO::PARAM_STR, ?int $length = null, $driverOptions = null): bool
     {
         $return = $this->statement->bindParam($parameter, $variable, $dataType, (int)$length, $driverOptions);
@@ -142,6 +143,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool
      */
+    #[\Override]
     public function bindValue($parameter, $value, int $dataType = PDO::PARAM_STR): bool
     {
         $return = $this->statement->bindValue($parameter, $value, $dataType);
@@ -170,6 +172,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool Returns TRUE on success or FALSE on failure.
      */
+    #[\Override]
     public function closeCursor(): bool
     {
         return $this->statement->closeCursor();
@@ -192,6 +195,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      * by the PDOStatement object. If there is no result set,
      * this method should return 0.
      */
+    #[\Override]
     public function columnCount(): int
     {
         return $this->statement->columnCount();
@@ -207,6 +211,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool
      */
+    #[\Override]
     public function execute(?array $inputParameters = null): bool
     {
         if ($this->connection->isInDebugMode()) {
@@ -247,6 +252,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return mixed
      */
+    #[\Override]
     public function fetch(int $fetchStyle = PDO::FETCH_BOTH, int $cursorOrientation = PDO::FETCH_ORI_NEXT, int $cursorOffset = 0)
     {
         return $this->statement->fetch($fetchStyle);
@@ -261,6 +267,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return array
      */
+    #[\Override]
     public function fetchAll(?int $fetchStyle = PDO::FETCH_BOTH, $fetchArgument = null, array $ctorArgs = []): array
     {
         return $this->statement->fetchAll($fetchStyle);
@@ -275,6 +282,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return string|null A single column in the next row of a result set.
      */
+    #[\Override]
     public function fetchColumn(int $columnIndex = 0): ?string
     {
         $output = $this->statement->fetchColumn($columnIndex);
@@ -295,6 +303,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return int The number of rows.
      */
+    #[\Override]
     public function rowCount(): int
     {
         return $this->statement->rowCount();
@@ -305,6 +314,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return \Traversable
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return $this->statement;
@@ -347,6 +357,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null): bool
     {
         return $this->statement->bindColumn($column, $param, $type, $maxlen, $driverdata);
@@ -355,6 +366,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fetchObject($className, array $ctorArgs = [])
     {
         return $this->statement->fetchObject($className, $ctorArgs);
@@ -363,6 +375,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function errorCode(): string
     {
         return $this->statement->errorCode();
@@ -371,6 +384,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function errorInfo(): array
     {
         return $this->statement->errorInfo();
@@ -379,6 +393,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setAttribute($attribute, $value): bool
     {
         return $this->statement->setAttribute($attribute, $value);
@@ -387,6 +402,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getAttribute($attribute)
     {
         return $this->statement->getAttribute($attribute);
@@ -395,6 +411,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getColumnMeta($column)
     {
         return $this->statement->getColumnMeta($column);
@@ -403,6 +420,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = []): bool
     {
         switch (func_num_args()) {
@@ -421,6 +439,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function nextRowset(): bool
     {
         return $this->statement->nextRowset();
@@ -429,6 +448,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function debugDumpParams(): void
     {
         $this->statement->debugDumpParams();

--- a/src/Propel/Runtime/DataFetcher/AbstractDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/AbstractDataFetcher.php
@@ -31,6 +31,7 @@ abstract class AbstractDataFetcher implements DataFetcherInterface
      *
      * @return void
      */
+    #[\Override]
     public function setDataObject($dataObject): void
     {
         $this->dataObject = $dataObject;
@@ -39,6 +40,7 @@ abstract class AbstractDataFetcher implements DataFetcherInterface
     /**
      * @return mixed|null
      */
+    #[\Override]
     public function getDataObject()
     {
         return $this->dataObject;
@@ -47,6 +49,7 @@ abstract class AbstractDataFetcher implements DataFetcherInterface
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function fetchColumn($index = null)
     {
         /** @var array|null $next */

--- a/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
@@ -25,6 +25,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         if ($this->dataObject !== null) {
@@ -37,6 +38,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function current()
     {
@@ -46,6 +48,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @return array|null
      */
+    #[\Override]
     public function fetch(): ?array
     {
         $row = $this->valid() ? $this->current() : null;
@@ -59,6 +62,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function key()
     {
@@ -68,6 +72,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function valid(): bool
     {
         return ($this->dataObject !== null && key($this->dataObject) !== null);
@@ -76,6 +81,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         if ($this->dataObject === null) {
@@ -88,6 +94,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getIndexType(): string
     {
         return $this->indexType;
@@ -96,6 +103,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function count(): int
     {
         return $this->dataObject === null ? 0 : count($this->dataObject);
@@ -116,6 +124,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
+    #[\Override]
     public function close(): void
     {
         $this->dataObject = null;

--- a/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
@@ -38,8 +38,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function current()
     {
         return $this->dataObject === null ? null : current($this->dataObject);
@@ -62,8 +61,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function key()
     {
         return $this->dataObject === null ? null : key($this->dataObject);

--- a/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
+++ b/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
@@ -43,8 +43,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return mixed Can return any type.
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function current();
 
     /**
@@ -66,8 +65,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return mixed scalar on success, or null on failure.
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function key();
 
     /**

--- a/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
+++ b/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
@@ -43,6 +43,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return mixed Can return any type.
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function current();
 
@@ -53,6 +54,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return void Any returned value is ignored.
      */
+    #[\Override]
     public function next(): void;
 
     /**
@@ -64,6 +66,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return mixed scalar on success, or null on failure.
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function key();
 
@@ -75,6 +78,7 @@ interface DataFetcherInterface extends Iterator, Countable
      * @return bool The return value will be casted to boolean and then evaluated.
      * Returns true on success or false on failure.
      */
+    #[\Override]
     public function valid(): bool;
 
     /**
@@ -84,6 +88,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return void Any returned value is ignored.
      */
+    #[\Override]
     public function rewind(): void;
 
     /**
@@ -116,6 +121,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int;
 
     /**

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -127,8 +127,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function current()
     {
         return $this->current;
@@ -139,8 +138,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
-    #[\Override]
-    #[\ReturnTypeWillChange]
+    #[\Override, \ReturnTypeWillChange]
     public function key()
     {
         return $this->index;

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -74,6 +74,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @return array|bool|null
      */
+    #[\Override]
     public function fetch(?int $style = null)
     {
         if ($style === null) {
@@ -110,6 +111,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
+    #[\Override]
     public function next(): void
     {
         if ($this->dataObject !== null) {
@@ -125,6 +127,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function current()
     {
@@ -136,6 +139,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @inheritDoc
      */
+    #[\Override]
     #[\ReturnTypeWillChange]
     public function key()
     {
@@ -145,6 +149,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function valid(): bool
     {
         return $this->current !== null && $this->current !== false;
@@ -157,6 +162,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @return void
      */
+    #[\Override]
     public function rewind(): void
     {
         if ($this->dataObject) {
@@ -167,6 +173,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
+    #[\Override]
     public function close(): void
     {
         /** @var \Propel\Runtime\Connection\StatementInterface|null $dataObject */
@@ -182,6 +189,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function count(): int
     {
         if ($this->dataObject && $this->dataObject->getConnection()->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
@@ -207,6 +215,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getIndexType(): string
     {
         return TableMap::TYPE_NUM;

--- a/src/Propel/Runtime/Formatter/AbstractFormatterWithHydration.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatterWithHydration.php
@@ -34,6 +34,7 @@ abstract class AbstractFormatterWithHydration extends AbstractFormatter
      *
      * @return array<string, mixed> The original record turned into an array
      */
+    #[\Override]
     public function formatRecord(?ActiveRecordInterface $record = null): array
     {
         return $record ? $record->toArray() : [];
@@ -44,6 +45,7 @@ abstract class AbstractFormatterWithHydration extends AbstractFormatter
      *
      * @return string|null
      */
+    #[\Override]
     public function getCollectionClassName(): ?string
     {
         return ArrayCollection::class;

--- a/src/Propel/Runtime/Formatter/ArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/ArrayFormatter.php
@@ -29,6 +29,7 @@ class ArrayFormatter extends AbstractFormatterWithHydration
      *
      * @return \Propel\Runtime\Collection\ArrayCollection
      */
+    #[\Override]
     public function format(?DataFetcherInterface $dataFetcher = null)
     {
         $this->checkInit();
@@ -69,6 +70,7 @@ class ArrayFormatter extends AbstractFormatterWithHydration
     /**
      * @return class-string<\Propel\Runtime\Collection\ArrayCollection>|null
      */
+    #[\Override]
     public function getCollectionClassName(): ?string
     {
         return '\Propel\Runtime\Collection\ArrayCollection';
@@ -81,6 +83,7 @@ class ArrayFormatter extends AbstractFormatterWithHydration
      *
      * @return array<string, mixed>|null
      */
+    #[\Override]
     public function formatOne(?DataFetcherInterface $dataFetcher = null): ?array
     {
         $this->checkInit();
@@ -118,6 +121,7 @@ class ArrayFormatter extends AbstractFormatterWithHydration
      *
      * @return array The original record turned into an array
      */
+    #[\Override]
     public function formatRecord(?ActiveRecordInterface $record = null): array
     {
         return $record ? $record->toArray() : [];
@@ -126,6 +130,7 @@ class ArrayFormatter extends AbstractFormatterWithHydration
     /**
      * @return bool
      */
+    #[\Override]
     public function isObjectFormatter(): bool
     {
         return false;

--- a/src/Propel/Runtime/Formatter/ObjectFormatter.php
+++ b/src/Propel/Runtime/Formatter/ObjectFormatter.php
@@ -36,6 +36,7 @@ class ObjectFormatter extends AbstractFormatter
      *
      * @return ListType
      */
+    #[\Override]
     public function format(?DataFetcherInterface $dataFetcher = null)
     {
         $this->checkInit();
@@ -77,6 +78,7 @@ class ObjectFormatter extends AbstractFormatter
     /**
      * @return class-string|null
      */
+    #[\Override]
     public function getCollectionClassName(): ?string
     {
         return $this->getTableMap()->getCollectionClassName();
@@ -89,6 +91,7 @@ class ObjectFormatter extends AbstractFormatter
      *
      * @return RowFormat|null
      */
+    #[\Override]
     public function formatOne(?DataFetcherInterface $dataFetcher = null): ?ActiveRecordInterface
     {
         $this->checkInit();
@@ -114,6 +117,7 @@ class ObjectFormatter extends AbstractFormatter
     /**
      * @return bool
      */
+    #[\Override]
     public function isObjectFormatter(): bool
     {
         return true;

--- a/src/Propel/Runtime/Formatter/OnDemandFormatter.php
+++ b/src/Propel/Runtime/Formatter/OnDemandFormatter.php
@@ -38,6 +38,7 @@ class OnDemandFormatter extends ObjectFormatter
      *
      * @return $this
      */
+    #[\Override]
     public function init(?BaseModelCriteria $criteria = null, ?DataFetcherInterface $dataFetcher = null)
     {
         parent::init($criteria, $dataFetcher);
@@ -54,6 +55,7 @@ class OnDemandFormatter extends ObjectFormatter
      *
      * @return \Propel\Runtime\Collection\OnDemandCollection<RowFormat>
      */
+    #[\Override]
     public function format(?DataFetcherInterface $dataFetcher = null): OnDemandCollection
     {
         $this->checkInit();
@@ -78,6 +80,7 @@ class OnDemandFormatter extends ObjectFormatter
     /**
      * @return class-string<\Propel\Runtime\Collection\Collection<\Propel\Runtime\ActiveRecord\ActiveRecordInterface>>
      */
+    #[\Override]
     public function getCollectionClassName(): string
     {
         return OnDemandCollection::class;
@@ -86,6 +89,7 @@ class OnDemandFormatter extends ObjectFormatter
     /**
      * @return \Propel\Runtime\Collection\OnDemandCollection<RowFormat>
      */
+    #[\Override]
     public function getCollection(): OnDemandCollection
     {
         $class = $this->getCollectionClassName();
@@ -106,6 +110,7 @@ class OnDemandFormatter extends ObjectFormatter
      *
      * @return RowFormat
      */
+    #[\Override]
     public function getAllObjectsFromRow(array $row): ActiveRecordInterface
     {
         $col = 0;

--- a/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
@@ -13,13 +13,15 @@ use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\LogicException;
 
 /**
+ * @deprecated class is not type-safe.
+ *
  * Array formatter for Propel select query
  * format() returns a ArrayCollection of associative arrays, a string,
  * or an array
  *
  * @author Benjamin Runnels
  *
- * @extends \Propel\Runtime\Formatter\AbstractFormatter<array<string, mixed>, \Propel\Runtime\Collection\ArrayCollection>
+ * @extends \Propel\Runtime\Formatter\AbstractFormatter<array<string, mixed>|string, \Propel\Runtime\Collection\ArrayCollection>
  */
 class SimpleArrayFormatter extends AbstractFormatter
 {
@@ -74,7 +76,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|string|null
      */
     #[\Override]
     public function formatOne(?DataFetcherInterface $dataFetcher = null)
@@ -130,7 +132,7 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * @param array $row
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|string
      */
     public function getStructuredArrayFromRow(array $row)
     {

--- a/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
@@ -30,6 +30,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\Collection\ArrayCollection
      */
+    #[\Override]
     public function format(?DataFetcherInterface $dataFetcher = null)
     {
         $this->checkInit();
@@ -62,6 +63,7 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * @return class-string<\Propel\Runtime\Collection\ArrayCollection>|null
      */
+    #[\Override]
     public function getCollectionClassName(): ?string
     {
         return '\Propel\Runtime\Collection\ArrayCollection';
@@ -74,6 +76,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function formatOne(?DataFetcherInterface $dataFetcher = null)
     {
         $this->checkInit();
@@ -109,6 +112,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @return array<string, mixed> The original record turned into an array
      */
+    #[\Override]
     public function formatRecord(?ActiveRecordInterface $record = null): array
     {
         return $record ? $record->toArray() : [];
@@ -117,6 +121,7 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * @return bool
      */
+    #[\Override]
     public function isObjectFormatter(): bool
     {
         return false;

--- a/src/Propel/Runtime/Formatter/StatementFormatter.php
+++ b/src/Propel/Runtime/Formatter/StatementFormatter.php
@@ -29,6 +29,7 @@ class StatementFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
+    #[\Override]
     public function format(?DataFetcherInterface $dataFetcher = null): DataFetcherInterface
     {
         if ($dataFetcher) {
@@ -45,6 +46,7 @@ class StatementFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface|null
      */
+    #[\Override]
     public function formatOne(?DataFetcherInterface $dataFetcher = null): ?DataFetcherInterface
     {
         $dataFetcher = $this->format($dataFetcher);
@@ -59,6 +61,7 @@ class StatementFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface|array
      */
+    #[\Override]
     public function formatRecord(?ActiveRecordInterface $record = null)
     {
         throw new PropelException('The Statement formatter cannot transform a record into a statement');
@@ -67,6 +70,7 @@ class StatementFormatter extends AbstractFormatter
     /**
      * @return bool
      */
+    #[\Override]
     public function isObjectFormatter(): bool
     {
         return false;

--- a/src/Propel/Runtime/Parser/CsvParser.php
+++ b/src/Propel/Runtime/Parser/CsvParser.php
@@ -76,6 +76,7 @@ class CsvParser extends AbstractParser
      *
      * @return string Converted data, as a CSV string
      */
+    #[\Override]
     public function fromArray(array $array, ?string $rootKey = null, bool $isList = false, bool $includeHeading = true): string
     {
         $rows = [];
@@ -104,6 +105,7 @@ class CsvParser extends AbstractParser
      *
      * @return string
      */
+    #[\Override]
     public function listFromArray(array $array, ?string $rootKey = null): string
     {
         return $this->fromArray($array, $rootKey, true);
@@ -234,6 +236,7 @@ class CsvParser extends AbstractParser
      *
      * @return array Converted data
      */
+    #[\Override]
     public function toArray(string $data, ?string $rootKey = null, bool $isList = false, bool $includeHeading = true): array
     {
         $rows = explode($this->lineTerminator, $data);
@@ -273,6 +276,7 @@ class CsvParser extends AbstractParser
      *
      * @return array
      */
+    #[\Override]
     public function listToArray(string $data, ?string $rootKey = null): array
     {
         return $this->toArray($data, $rootKey, true);

--- a/src/Propel/Runtime/Parser/JsonParser.php
+++ b/src/Propel/Runtime/Parser/JsonParser.php
@@ -23,6 +23,7 @@ class JsonParser extends AbstractParser
      *
      * @return string Converted data, as a JSON string
      */
+    #[\Override]
     public function fromArray(array $array, ?string $rootKey = null): string
     {
         return json_encode($rootKey === null ? $array : [$rootKey => $array], JSON_THROW_ON_ERROR);
@@ -49,6 +50,7 @@ class JsonParser extends AbstractParser
      *
      * @return array Converted data
      */
+    #[\Override]
     public function toArray(string $data, ?string $rootKey = null): array
     {
         $data = json_decode($data, true);

--- a/src/Propel/Runtime/Parser/XmlParser.php
+++ b/src/Propel/Runtime/Parser/XmlParser.php
@@ -30,6 +30,7 @@ class XmlParser extends AbstractParser
      *
      * @return string Converted data, as an XML string
      */
+    #[\Override]
     public function fromArray(array $array, string $rootKey = 'data', ?string $charset = null): string
     {
         $rootNode = $this->getRootNode($rootKey);
@@ -46,6 +47,7 @@ class XmlParser extends AbstractParser
      *
      * @return string
      */
+    #[\Override]
     public function listFromArray(array $array, ?string $rootKey = 'data', ?string $charset = null): string
     {
         $rootNode = $this->getRootNode($rootKey);
@@ -155,6 +157,7 @@ class XmlParser extends AbstractParser
      *
      * @return array Converted data
      */
+    #[\Override]
     public function toArray(string $data, string $rootKey = 'data'): array
     {
         $doc = new DOMDocument('1.0', 'UTF-8');

--- a/src/Propel/Runtime/Parser/YamlParser.php
+++ b/src/Propel/Runtime/Parser/YamlParser.php
@@ -25,6 +25,7 @@ class YamlParser extends AbstractParser
      *
      * @return string Converted data, as a YAML string
      */
+    #[\Override]
     public function fromArray(array $array, ?string $rootKey = null): string
     {
         return Yaml::dump($rootKey === null ? $array : [$rootKey => $array], 3);
@@ -51,6 +52,7 @@ class YamlParser extends AbstractParser
      *
      * @return array Converted data
      */
+    #[\Override]
     public function toArray(string $data, ?string $rootKey = null): array
     {
         $data = Yaml::parse($data);

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -117,6 +117,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * @return string
      */
+    #[\Override]
     public function getDefaultDatasource(): string
     {
         return $this->defaultDatasource;
@@ -139,6 +140,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return string
      */
+    #[\Override]
     public function getAdapterClass(?string $name = null): string
     {
         if ($name === null) {
@@ -188,6 +190,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface
      */
+    #[\Override]
     public function getAdapter(?string $name = null): AdapterInterface
     {
         if ($name === null) {
@@ -261,6 +264,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
+    #[\Override]
     public function initDatabaseMaps(array $databaseNameToTableMapClassNames = []): void
     {
         if ($this->databaseMaps === null) {
@@ -315,6 +319,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Map\DatabaseMap
      */
+    #[\Override]
     public function getDatabaseMap(?string $name = null): DatabaseMap
     {
         if (!$name) {
@@ -369,6 +374,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionManagerInterface
      */
+    #[\Override]
     public function getConnectionManager(string $name): ConnectionManagerInterface
     {
         if (!isset($this->connectionManagers[$name])) {
@@ -383,6 +389,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return bool true if a connectionManager with $name has been registered
      */
+    #[\Override]
     public function hasConnectionManager(string $name): bool
     {
         return isset($this->connectionManagers[$name]);
@@ -404,6 +411,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
+    #[\Override]
     public function closeConnections(): void
     {
         foreach ($this->connectionManagers as $manager) {
@@ -422,6 +430,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
+    #[\Override]
     public function getConnection(?string $name = null, string $mode = ServiceContainerInterface::CONNECTION_WRITE): ConnectionInterface
     {
         if ($name === null) {
@@ -446,6 +455,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
+    #[\Override]
     public function getWriteConnection(string $name): ConnectionInterface
     {
         return $this->getConnectionManager($name)->getWriteConnection($this->getAdapter($name));
@@ -463,6 +473,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
+    #[\Override]
     public function getReadConnection(string $name): ConnectionInterface
     {
         return $this->getConnectionManager($name)->getReadConnection($this->getAdapter($name));
@@ -535,6 +546,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Util\Profiler
      */
+    #[\Override]
     public function getProfiler(): Profiler
     {
         if ($this->profiler === null) {
@@ -557,6 +569,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Psr\Log\LoggerInterface
      */
+    #[\Override]
     public function getLogger(?string $name = null): LoggerInterface
     {
         if ($name === null) {

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -194,6 +194,7 @@ class PropelDateTime extends DateTime
      *
      * @return void
      */
+    #[\Override]
     public function __wakeup(): void
     {
         // @TODO I don't think we can call the constructor from within this method

--- a/src/Propel/Runtime/Util/PropelModelPager.php
+++ b/src/Propel/Runtime/Util/PropelModelPager.php
@@ -441,6 +441,7 @@ class PropelModelPager implements IteratorAggregate, Countable
     /**
      * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable
      */
+    #[\Override]
     public function getIterator(): Traversable
     {
         return $this->getResults()->getIterator();
@@ -453,6 +454,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->getResults());

--- a/src/Propel/Runtime/Validator/Constraints/DateValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/DateValidator.php
@@ -25,6 +25,7 @@ class DateValidator extends SymfonyDateValidator
      *
      * @return void
      */
+    #[\Override]
     public function validate($value, Constraint $constraint): void
     {
         if ($value instanceof DateTimeInterface) {

--- a/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
@@ -20,6 +20,7 @@ class UniqueValidator extends ConstraintValidator
      *
      * @return void
      */
+    #[\Override]
     public function validate($value, Constraint $constraint): void
     {
         if ($value === null) {


### PR DESCRIPTION
Update PHP Psalm to latest version (v6).

Latest version expects `#[\Override]` attributes on overridden methods/interface implementations, so you can see that the implemented method is based on another, which I like. 

[Psalm says](https://psalm.dev/docs/running_psalm/issues/MissingOverrideAttribute/) the override attribute requires symfony/polyfill, so I added those.

Did some small cleanup where it was obvious.

Played around with going to more strict Psalm level 5, some fixes will be in another PR. 