### PR TITLE
remove symfony/polyfill replacements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,7 @@
         "monolog/monolog": "The recommended logging library to use with Propel."
     },
     "replace": {
-        "propel/propel": "dev-main as 2.0.x-dev",
-        "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-intl-grapheme": "*",
-        "symfony/polyfill-intl-normalizer": "*"
+        "propel/propel": "dev-main as 2.0.x-dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The `replace' statements in composer.json regarding symfony/polyfill break projects that depend on those packages.

PR removes those statements.

Reported in [review discussion](https://github.com/mringler/perpl/pull/49#discussion_r2068190415) by @rvanvelzen (thank you!).